### PR TITLE
Refactor: Move logic from EntryPoint and EntriesPoint models to ImsService

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install -g gulp ionic
+  - npm install -g gulp ionic@2.2.1
 script: 
   - gulp lint
   - npm run test-coverage

--- a/src/models/entries-point.ts
+++ b/src/models/entries-point.ts
@@ -6,13 +6,4 @@ export class EntriesPoint {
     constructor(filters: Filter[]) {
         this.filters = filters;
     }
-
-    getLinkHref(filterId: number): string {
-        for (let filter of this.filters) {
-            if (filter.id === filterId.toString()) {
-                return filter.dataHref;
-            }
-        }
-        throw new TypeError('No filterId: ' + filterId + ' found');
-    }
 }

--- a/src/models/entry-point.ts
+++ b/src/models/entry-point.ts
@@ -6,13 +6,4 @@ export class EntryPoint {
     constructor(links: Link[]) {
         this.links = links;
     }
-
-    getLinkHref(linkName: string): string {
-        for (let link of this.links) {
-            if (link.link === linkName) {
-                return link.dataHref;
-            }
-        }
-        throw new TypeError('No linkName: ' + linkName + ' found');
-    }
 }

--- a/src/providers/ims-service.spec.ts
+++ b/src/providers/ims-service.spec.ts
@@ -29,18 +29,20 @@ describe('Provider: ImsService', () => {
 
 
   it('Ims Version', inject([ImsService, MockImsBackend], (imsService: ImsService, mockImsBackend: MockImsBackend) => {
-      imsService.getInfo(mockImsBackend.credential).subscribe(info => expect(info.version).toEqual(mockImsBackend.version));
-  }));
-
-  it('Should get link to license resource', inject([ImsService, MockImsBackend], (imsService: ImsService, mockImsBackend: MockImsBackend) => {
-    imsService.getEntryPoint(mockImsBackend.credential).subscribe(
-      entryPoint => expect(entryPoint.getLinkHref('license')).toEqual(mockImsBackend.licenseUrl),
+    imsService.getInfo(mockImsBackend.credential).subscribe(
+      info => expect(info.version).toEqual(mockImsBackend.version),
       err => fail(err));
   }));
 
- it('Should get link to entries resource', inject([ImsService, MockImsBackend], (imsService: ImsService, mockImsBackend: MockImsBackend) => {
-    imsService.getEntryPoint(mockImsBackend.credential).subscribe(
-      entryPoint => expect(entryPoint.getLinkHref('entries')).toEqual(mockImsBackend.entriesUrl),
+  it('Should get link to license resource', inject([ImsService, MockImsBackend], (imsService: ImsService, mockImsBackend: MockImsBackend) => {
+    imsService.getEntryPointLink(mockImsBackend.credential, 'license').subscribe(
+      entryPoint => expect(entryPoint).toEqual(mockImsBackend.licenseUrl),
+      err => fail(err));
+  }));
+
+  it('Should get link to entries resource', inject([ImsService, MockImsBackend], (imsService: ImsService, mockImsBackend: MockImsBackend) => {
+    imsService.getEntryPointLink(mockImsBackend.credential, 'entries').subscribe(
+      entryPoint => expect(entryPoint).toEqual(mockImsBackend.entriesUrl),
       err => fail(err));
   }));
 

--- a/src/providers/ims-service.ts
+++ b/src/providers/ims-service.ts
@@ -90,12 +90,13 @@ export class ImsService {
     return this.http.get(url, { headers: headers });
   }
 
+  // tslint:disable-next-line
   private findEntryPointLinkByName(this: string, link: Link): boolean {
     return link.link === this;
   }
 
+  // tslint:disable-next-line
   private findFilterLinkById(this: number, filter: Filter): boolean {
     return filter.id === this.toString();
   }
-
 }

--- a/src/providers/ims-service.ts
+++ b/src/providers/ims-service.ts
@@ -11,6 +11,8 @@ import { EntriesPoint } from '../models/entries-point';
 import { Token } from '../models/token';
 import { ArchiveEntry } from '../models/archiveEntry';
 import { ArchiveTableEntry } from '../models/archiveTableEntry';
+import { Link } from '../models/link';
+import { Filter } from '../models/filter';
 
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
@@ -27,7 +29,7 @@ export class ImsService {
   }
 
   getEntriesFilterUrl(credential: Credential, filterId: number): Observable<string> {
-    return this.getEntriesTable(credential).map(entriesPoint => entriesPoint.getLinkHref(filterId));
+    return this.getEntriesTable(credential).map(entriesPoint => entriesPoint.filters.find(this.findFilterLinkById, filterId).dataHref);
   }
 
   getInfo(credential: Credential): Observable<Info> {
@@ -76,18 +78,24 @@ export class ImsService {
   }
 
   getEntryPointLink(credential: Credential, linkConstant: string): Observable<string> {
-    return this.getEntryPoint(credential).map(entryPoint => entryPoint.getLinkHref(linkConstant));
+    return this.getEntryPoint(credential).map(entryPoint => entryPoint.links.find(this.findEntryPointLinkByName, linkConstant).dataHref);
   }
 
   getEntryPoint(credential: Credential): Observable<EntryPoint> {
-    return this.get(credential, credential.server + '/rest').map(response => {
-      return new EntryPoint(response.json().links);
-    });
+    return this.get(credential, credential.server + '/rest').map(response => response.json());
   }
 
   get(credential: Credential, url: string): Observable<Response> {
     let headers = new ImsHeaders(credential);
     return this.http.get(url, { headers: headers });
+  }
+
+  private findEntryPointLinkByName(link: Link): boolean {
+    return link.link === this.toString();
+  }
+
+  private findFilterLinkById(filter: Filter): boolean {
+    return filter.id === this.toString();
   }
 
 }

--- a/src/providers/ims-service.ts
+++ b/src/providers/ims-service.ts
@@ -90,11 +90,11 @@ export class ImsService {
     return this.http.get(url, { headers: headers });
   }
 
-  private findEntryPointLinkByName(link: Link): boolean {
-    return link.link === this.toString();
+  private findEntryPointLinkByName(this: string, link: Link): boolean {
+    return link.link === this;
   }
 
-  private findFilterLinkById(filter: Filter): boolean {
+  private findFilterLinkById(this: number, filter: Filter): boolean {
     return filter.id === this.toString();
   }
 


### PR DESCRIPTION
Using `thisArg` from `Array.prototype.find()` to get a parameterized `find()`.