### PR TITLE
Pin ionic cli version in CI to pre v3 (unbreak CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install -g gulp ionic
+  - npm install -g gulp ionic@2.2.1
 script: 
   - gulp lint
   - npm run test-coverage


### PR DESCRIPTION
Quick workaround to unbreak CI build due to breaking changes in `ionic package` starting with ionic-cli v3.
Created #278 to update our CI to ionic-cli v3.