### PR TITLE
Pin ionic cli version in CI to v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install -g gulp ionic@2.2.1
+  - npm install -g gulp ionic@2.2.3
 script: 
   - gulp lint
   - npm run test-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install -g gulp ionic@2.2.3
+  - npm install -g gulp ionic@2
 script: 
   - gulp lint
   - npm run test-coverage


### PR DESCRIPTION
Fix wrongly pinned version, which broke ios packaging.
Improvement on #279 