### PR TITLE
Login Form: disable username autocapitalization and set type on url

### DIFF
--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -9,11 +9,11 @@
   <form [formGroup]="loginForm" (ngSubmit)="login()">
     <ion-item *ngIf="isShowRestUrlField === true">
       <ion-icon name="cloud" item-start></ion-icon>
-      <ion-input placeholder="IMS Rest Url" formControlName="server"></ion-input>
+      <ion-input type="url" placeholder="IMS Rest Url" formControlName="server"></ion-input>
     </ion-item>
     <ion-item>
       <ion-icon name="person" item-start></ion-icon>
-      <ion-input placeholder="IMS Benutzername" formControlName="user" [class.invalid]="submitAttempt"></ion-input>
+      <ion-input placeholder="IMS Benutzername" formControlName="user" [class.invalid]="submitAttempt" autocapitalize="none"></ion-input>
     </ion-item>
     <ion-item>
       <ion-icon name="lock" item-start></ion-icon>


### PR DESCRIPTION
This should provide the correct keyboard layout for the URL input and be more comfortable for inputting (usually) lowercase usernames.

Tested on Android (may depend on installed keyboard) and iOS (with Ionic View only)