### PR TITLE
store generic camera options in one place

### DIFF
--- a/src/providers/camera-service.ts
+++ b/src/providers/camera-service.ts
@@ -7,25 +7,22 @@ import 'rxjs/add/observable/fromPromise';
 @Injectable()
 export class CameraService {
 
-  pictureOptions: CameraOptions = {
+  cameraOptions: CameraOptions = {
     quality: 100,
-    sourceType: this.camera.PictureSourceType.CAMERA,
     destinationType: this.camera.DestinationType.FILE_URI,
     encodingType: this.camera.EncodingType.JPEG,
     mediaType: this.camera.MediaType.PICTURE,
     correctOrientation: true
   };
 
-  galleryOptions: CameraOptions = {
-    quality: 100,
-    sourceType: this.camera.PictureSourceType.PHOTOLIBRARY,
-    destinationType: this.camera.DestinationType.FILE_URI,
-    encodingType: this.camera.EncodingType.JPEG,
-    mediaType: this.camera.MediaType.PICTURE,
-    correctOrientation: true
-  };
+  pictureOptions: CameraOptions = Object.assign({
+    sourceType: this.camera.PictureSourceType.CAMERA
+  }, this.cameraOptions);
+  galleryOptions: CameraOptions = Object.assign({
+    sourceType: this.camera.PictureSourceType.PHOTOLIBRARY
+  }, this.cameraOptions);
 
-  ignoredErrors: (string|number)[] = [
+  ignoredErrors: (string | number)[] = [
     'Selection cancelled.',    // Android
     'Camera cancelled.',       // Android
     20,                        // Android: permission not granted
@@ -44,7 +41,7 @@ export class CameraService {
     return Observable.fromPromise(this.camera.getPicture(this.galleryOptions));
   }
 
-  public showAlertOnError(error: (string|number)) {
+  public showAlertOnError(error: (string | number)) {
     if (this.ignoredErrors.indexOf(error) === -1) {
       if (typeof error === 'number') {
         error = this.errorCodePreMessage + error;


### PR DESCRIPTION
Using [`Object.assign`](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) to copy the generic `cameraOptions` to `pictureOptions` and `galleryOptions`.

Depending on PR #391 the version needs to be increased approprately.