### PR TITLE
Login Page: remove markAsTouched

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="io.github.imsmobile.app" version="0.2.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="io.github.imsmobile.app" version="0.2.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>ims</name>
   <description>Imagic IMS Mobile Client</description>
   <author email="imsmobile@pobox.com" href="https://github.com/IMSmobile/app">Imagic IMS Mobile Client Team</author>

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
     "tslint-ionic-rules": "0.0.8",
     "typescript": "2.2.1"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Cross-Platform Ionic App for IMS"
 }

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -32,7 +32,6 @@ export class LoginPage {
   }
 
   login() {
-    this.markAllAsTouched();
     if (this.loginForm.invalid) {
       this.showToastMessage('Alle Felder müssen ausgefüllt werden');
     } else {
@@ -78,12 +77,6 @@ export class LoginPage {
       duration: 3000,
     });
     toast.present();
-  }
-
-  markAllAsTouched() {   // TODO this.loginForm.markAsTouched (mark all as touched in a single call) did not working maybe after update to Ionic
-    this.loginForm.controls['server'].markAsTouched();
-    this.loginForm.controls['user'].markAsTouched();
-    this.loginForm.controls['password'].markAsTouched();
   }
 
   ionViewDidLoad() {

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -21,7 +21,7 @@ export class LoginPage {
 
   loginForm: FormGroup;
   isShowRestUrlField: boolean = true;
-  version: string = '0.2.0';
+  version: string = '0.2.1';
 
   constructor(public navCtrl: NavController, public navParams: NavParams, private formBuilder: FormBuilder, public loadingService: LoadingService, public alertCtrl: AlertController, public toastCtrl: ToastController, public authService: AuthService, public settingService: SettingService) {
     this.loginForm = this.formBuilder.group({


### PR DESCRIPTION
As there are only three fields and no special validation it should be obvious what is invalid.
Also we disabled the red underlinig of invalid forms anyway in 6b6f0a9.

On the upload page we need to keep the `markAllAsTouched()` as it needs to be obvious which (of the possibily many) fields are invalid when hitting the upload button and getting the toast.

The marking of all child controls as touched is still not available in Angular.


