### PR TITLE
feat(upload): show boolean toggle for boolean upload field type

### DIFF
--- a/e2e/page-objects/upload-page-object.ts
+++ b/e2e/page-objects/upload-page-object.ts
@@ -13,6 +13,7 @@ export class UploadPageObject {
   textfeldFieldInput: ElementFinder = element(by.css('input[ng-reflect-name=TEXTFELD]'));
   integerfeldFieldInput: ElementFinder = element(by.css('input[ng-reflect-name=INTEGERFELD]'));
   floatfeldFieldInput: ElementFinder = element(by.css('input[ng-reflect-name=FLOATFELD]'));
+  booleanFieldToggle: ElementFinder = element(by.css('ion-toggle[ng-reflect-name=BOOLEANNO]'));
   uploadFieldErrorDivBILDNAME: ElementFinder = element(by.id('uploadFieldErrorDivBILDNAME'));
   uploadFieldErrorDivINTEGERFELD: ElementFinder = element(by.id('uploadFieldErrorDivINTEGERFELD'));
   uploadFieldErrorDivFLOATFELD: ElementFinder = element(by.id('uploadFieldErrorDivFLOATFELD'));
@@ -34,6 +35,12 @@ export class UploadPageObject {
     Helpers.waitUntilElementIsReady(textField);
     textField.clear();
     textField.sendKeys(text);
+    browser.waitForAngular();
+  }
+
+  toggleBooleanField() {
+    Helpers.waitUntilElementIsReady(this.booleanFieldToggle);
+    this.booleanFieldToggle.click();
     browser.waitForAngular();
   }
 

--- a/e2e/upload.e2e-spec.ts
+++ b/e2e/upload.e2e-spec.ts
@@ -45,9 +45,12 @@ describe('Upload E2E Test', () => {
   });
 
   it('Should upload image taken from gallery', () => {
-    entriesPage.loadPage();
-    entriesPage.pushEntriesGalleryButtonOnEntry34617();
+    settingImageFieldsPageObject.loadPage();
+    Helpers.toggleFieldSettings(settingImageFieldsPageObject.settingsImageFieldBOOLEANNOToggle);
+
+    uploadPage.reloadPage();
     uploadPage.writeToTextField(uploadPage.bildNameFieldInput, 'e2e Test');
+    uploadPage.toggleBooleanField();
     uploadPage.clickUploadImageButton();
     browser.wait(ExpectedConditions.visibilityOf(element(by.className('toast-message'))), Helpers.DEFAULT_WAIT_TIMEOUT);
   });

--- a/src/pages/upload/upload.html
+++ b/src/pages/upload/upload.html
@@ -32,9 +32,10 @@
     <ion-list *ngSwitchCase="'metadata'" id="id-list">
       <form [formGroup]="fieldsForm">
         <div *ngFor="let field of fields">
-          <ion-item>
+          <ion-item [ngSwitch]="field.type">
             <ion-label>{{field.name}}<span *ngIf="field.mandatory" class="mandatory" id="mandatory{{field.name}}"> *</span></ion-label>
-            <ion-input type="text" formControlName="{{field.name}}"></ion-input>
+            <ion-toggle *ngSwitchCase="'BOOLEAN'" formControlName="{{field.name}}"></ion-toggle>
+            <ion-input *ngSwitchDefault type="text" formControlName="{{field.name}}"></ion-input>
           </ion-item>
           <div class="invalid" *ngIf="!fieldsForm.controls[field.name].valid && (fieldsForm.controls[field.name].touched || fieldsForm.controls[field.name].dirty) " id="uploadFieldErrorDiv{{field.name}}">
             <p>{{getErrorMessage(fieldsForm.controls[field.name])}}</p>

--- a/src/pages/upload/upload.spec.ts
+++ b/src/pages/upload/upload.spec.ts
@@ -1,3 +1,4 @@
+import { MetadataField } from './../../models/metadata-field';
 import { BrowserFileuploadSelectorService } from './../../providers/browser-fileupload-selector-service';
 import { ContainerUploadService } from './../../providers/container-upload-service';
 import { ImsUploadError } from './../../models/errors/ims-upload-error';
@@ -140,7 +141,7 @@ describe('Page: Upload', () => {
   it('Update imagename when new file in fileinput is selected', () => {
     let fileName = 'newFile.jpg';
     let fileURI = '/dev/0/';
-    let oldImage = new Image ('oldvalue', 'oldvalue.jpg');
+    let oldImage = new Image('oldvalue', 'oldvalue.jpg');
     let newFile: File = new File([new Blob()], fileName);
     let newImage = new Image(fileName, fileURI, newFile);
     spyOn(window.URL, 'createObjectURL').and.returnValue(fileURI);
@@ -151,7 +152,7 @@ describe('Page: Upload', () => {
   });
 
   it('Do nothing when no file available in input file dialog', () => {
-    let oldImage = new Image ('oldvalue', 'oldvalue.jpg');
+    let oldImage = new Image('oldvalue', 'oldvalue.jpg');
     page.image = oldImage;
     let event = { target: { files: [] } };
     page.fileSelected(event);
@@ -279,6 +280,18 @@ describe('Page: Upload', () => {
     let control = new FormControl('12a', DoubleValidator.isValid);
     page.getErrorMessage(control);
     expect(fieldValidatorService.getErrorMessage).toHaveBeenCalledWith(control);
+  }));
+
+  it('Initialize BOOLEAN field type as false', inject([ImsBackendMock, AuthService, LoadingService, SettingService], (imsBackendMock: ImsBackendMock, authService: AuthService, loadingService: LoadingService, settingService: SettingService) => {
+    page.fields = [new MetadataField('booleanField', 'BOOLEAN', false, false, true, true, 10)];
+    page.initFormData();
+    expect(page.fieldsForm.controls['booleanField'].value).toEqual('false');
+  }));
+
+  it('Initialize Text field type as empty string', inject([ImsBackendMock, AuthService, LoadingService, SettingService], (imsBackendMock: ImsBackendMock, authService: AuthService, loadingService: LoadingService, settingService: SettingService) => {
+    page.fields = [new MetadataField('textField', 'TEXT', false, false, true, true, 10)];
+    page.initFormData();
+    expect(page.fieldsForm.controls['textField'].value).toEqual('');
   }));
 
 });

--- a/src/pages/upload/upload.ts
+++ b/src/pages/upload/upload.ts
@@ -73,11 +73,19 @@ export class UploadPage {
   initFormData() {
     let formData = {};
     this.fields.forEach(field => {
-      formData[field.name] = [''];
+      formData[field.name] = [this.getDefaultValue(field.type)];
       formData[field.name].push(Validators.compose(this.fieldValidatorService.getValidatorFunctions(field)));
     });
     this.fieldsForm = this.formBuilder.group(formData);
   }
+
+  getDefaultValue(type: string): string {
+    switch (type) {
+      case 'BOOLEAN': return 'false';
+      default: return '';
+    }
+  }
+
 
   public takePicture() {
     this.loadingService.subscribeWithLoading(


### PR DESCRIPTION
User should not be allowed to enter wrong input for boolean field type. The application now shows a toggle instead of an input field for boolean field types.

Closes #338 