### PR TITLE
build:  add automatic release creation with node script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,7 @@ Eine Issue gilt als abgeschlossen wenn:
 - Der Pull Request einem Review unterzogen wurde und unseren Qualitätsanforderungen entspricht
 - Das Issue geschlossen wurde (entweder durch Commit-Messages oder manuell auf dem Kanbanboard)
 - Die Funktionalität auf einem iOS und Android Gerät getestet wurde
-- Die Version (gemäss Semantic Versioning) in folgenden Files erhöht wurde
-  - `package.json`
-  - `src/pages/login.ts`
-  - `config.xml`
+
 
 ## Pull Request Format
 Weil wir Pull Requests auf den master squashen um automatiserte Release Notes generieren zu können müssen die Angaben einem speziellen Format entsprechen. Das Format basiert auf den [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines). Der Pull Request wird in Englisch geschrieben.

--- a/README.md
+++ b/README.md
@@ -413,9 +413,17 @@ Um rasch neue Versionen des Clients bereitstellen zu können setzen wir auf die 
 
 Dabei wird in einem ersten Schritt die Relevanz der Änderung anhand des [Commit Message Formats](#commit-message-guidelines) beurteilt und die Versionsnummer entsprechend erhöht. Anschliessend werden die Release Notes generiert und der Release freigegeben.
 
-Für die [Versionierung](#versionierung) relevant sind nur Commit Messages vom [Typ](CONTRIBUTING.md#type) `fix`, `feature` oder `perf` sowie Breaking Changes. Es ist Aufgabe des Reviewers nach dem mergen solcher Pull Requests die Erstellung eines neuen Releases anzustossen. Dabei kreiert er einen weiteren Pull Request in dem sich die neue Versionsnummer, eine Markierung (`tag`) für die Versionsverwaltung sowie die aktualisierte Sammlung aller Release Notes ([`CHANGELOG.md`](CHANGELOG.md)) befindet.
+Für die [Versionierung](#versionierung) relevant sind nur Commit Messages vom [Typ](CONTRIBUTING.md#type) `fix`, `feature` oder `perf` sowie Breaking Changes. Es ist Aufgabe des Reviewers nach dem mergen solcher Pull Requests die Erstellung eines neuen Releases anzustossen. Wenn ein neuer Release gemacht werden muss, führt er den Release Befehl aus. 
 
-Anschliessend wird dieser zweite "Release Pull Request" durch einen weiteren Reviewer beurteilt und gemerged. Dessen Aufgabe ist es wiederum den Release auf GitHub bereitzustellen.
+```shell
+npm run release
+```
+
+Mit diesem Kommando wird  die neue Versionsnummer erstellt und automatisch aktualisiert, eine Markierung (`tag`) für die Versionsverwaltung erstellt sowie die aktualisierte Sammlung aller Release Notes ([`CHANGELOG.md`](CHANGELOG.md)) generiert.
+
+Anschliessend wird diese Änderung direkt auf dem Master Branch commited. Dafür muss temporär die Commit Berechtigung auf Github aktiviert werden. 
+
+Nach dem Commit muss der Reviewer den Release auf GitHub bereitzustellen und die temporäre Commit Berechtigung wieder aufheben.
 
 ### Versionierung
 Eine Version nach Semantic Versioning besteht aus den drei Komponenten _MAJOR_, _MINOR_ und _PATCH_ welche je nach Commit Message Typ inkrementiert werden.

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Um rasch neue Versionen des Clients bereitstellen zu können setzen wir auf die 
 
 Dabei wird in einem ersten Schritt die Relevanz der Änderung anhand des [Commit Message Formats](#commit-message-guidelines) beurteilt und die Versionsnummer entsprechend erhöht. Anschliessend werden die Release Notes generiert und der Release freigegeben.
 
-Für die [Versionierung](#versionierung) relevant sind nur Commit Messages vom [Typ](CONTRIBUTING.md#type) `fix`, `feature` oder `perf` sowie Breaking Changes. Es ist Aufgabe des Reviewers nach dem mergen solcher Pull Requests die Erstellung eines neuen Releases anzustossen. Wenn ein neuer Release gemacht werden muss, führt er den Release Befehl aus. 
+Für die [Versionierung](#versionierung) relevant sind nur Commit Messages vom [Typ](CONTRIBUTING.md#type) `fix`, `feature` oder `perf` sowie Breaking Changes. Es ist Aufgabe des Reviewers nach dem mergen solcher Pull Requests die Erstellung eines neuen Releases anzustossen mit dem Befehl 
 
 ```shell
 npm run release
@@ -421,9 +421,9 @@ npm run release
 
 Mit diesem Kommando wird  die neue Versionsnummer erstellt und automatisch aktualisiert, eine Markierung (`tag`) für die Versionsverwaltung erstellt sowie die aktualisierte Sammlung aller Release Notes ([`CHANGELOG.md`](CHANGELOG.md)) generiert.
 
-Anschliessend wird diese Änderung direkt auf dem Master Branch commited. Dafür muss temporär die Commit Berechtigung auf Github aktiviert werden. 
+Anschliessend wird diese Änderung vom Reviewer direkt auf dem Master Branch commited. Dafür muss temporär der Schutz des Master Braches auf GitHub aufgehoben werden.
 
-Nach dem Commit muss der Reviewer den Release auf GitHub bereitzustellen und die temporäre Commit Berechtigung wieder aufheben.
+Nach dem Commit muss der Reviewer den Schutz sofort wieder aktivieren und den Release unter der entsprechenden Versionsnummer auf GitHub bereitstellen.
 
 ### Versionierung
 Eine Version nach Semantic Versioning besteht aus den drei Komponenten _MAJOR_, _MINOR_ und _PATCH_ welche je nach Commit Message Typ inkrementiert werden.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "karma start ./test-config/karma.conf.js",
     "test-coverage": "karma start ./test-config/karma.conf.js --coverage",
     "e2e": "npm run clean && npm run build && node node_modules/protractor/bin/webdriver-manager update && node node_modules/protractor/bin/protractor",
-    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
+    "release": "node scripts/release.js"
   },
   "config": {
     "ionic_source_map": "source-map",
@@ -62,8 +62,8 @@
     "@types/jasmine": "^2.5.41",
     "@types/node": "^7.0.8",
     "angular2-template-loader": "^0.6.2",
-    "connect": "^3.6.1",
     "codelyzer": "3.0.1",
+    "connect": "^3.6.1",
     "conventional-changelog-cli": "^1.3.1",
     "cz-conventional-changelog": "^2.0.0",
     "html-loader": "^0.4.5",
@@ -84,6 +84,7 @@
     "null-loader": "^0.1.1",
     "protractor": "^5.1.1",
     "remap-istanbul": "^0.9.5",
+    "standard-version": "^4.2.0",
     "systemjs": "^0.20.12",
     "ts-loader": "^2.0.3",
     "ts-node": "^3.0.4",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const exec = require('child_process').exec;
+
+const standardVersion = require('standard-version');
+const packageJsonFile = path.resolve(__dirname, '../package.json');
+const configXmlFile = path.resolve(__dirname, '../config.xml');
+const loginTsFile = path.resolve(__dirname, '../src/pages/login/login.ts');
+var packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'utf8'));
+
+var versionBefore = packageJson['version'];
+
+standardVersion({ "skip": { "commit": true }, }).then(function succ() {
+  packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'utf8'));
+  var newVersion = packageJson['version'];
+  replaceInFile(configXmlFile, 'id="io.github.imsmobile.app" version="' + versionBefore + '"', 'id="io.github.imsmobile.app" version="' + newVersion + '"');
+  replaceInFile(loginTsFile, 'version: string = \'' + versionBefore + '\'', 'version: string = \'' + newVersion + '\'');
+  exec('git tag -d v' + newVersion);
+  exec('git tag ' + newVersion);
+});
+
+
+function replaceInFile(file, searchValue, replaceValue) {
+  var content = fs.readFileSync(file, 'utf8');
+  var contentReplaced = content.replace(searchValue, replaceValue);
+  fs.writeFileSync(file, contentReplaced, 'utf8');
+}


### PR DESCRIPTION
Automatic creation of changelog was not working because tag have been deleted after squash commit. The new described workflow allows release generation directly on master branch and shortens the release process.

This closes #429 