### PR TITLE
docs: add protocol from sprint review 9

### DIFF
--- a/docs/protocols/2017-06-30-presentation-sprint9-imagic_PICSystem.md
+++ b/docs/protocols/2017-06-30-presentation-sprint9-imagic_PICSystem.md
@@ -19,9 +19,9 @@ Ionic App Entwickler: Michael Leu, Niklaus Tschirky, Sandro Zbinden
 ### Abgeschlossene Aufgaben
 - Dokumentation "Austausch von Logos/Grafiken"
 - Entfernen des Settings-Popover für vereinfachtes GUI und iOS-näheren Verhalten
-- Schiebe Knopf für Boolean Felder
+- Toggle Button für Boolean Felder
 - Browserversion Kamerabutton entfernt und Fileupload mit Auswahlfenster hinzugefügt
-- Releasing überarbeitet (automatisches Generieren von Release Notes, definieren von einheitlichen Commitmessages, Autoupdate von Versionsnummer)
+- Releasing überarbeitet (automatische Generierung von Release Notes, definieren von einheitlichen Commitmessages, Autoupdate von Versionsnummer)
 - Upload Fehler bei langsamen Netzwerken durch Caddy Update gelöst
 - Lintregeln überarbeitet
 - Update auf neuste Ionic Version 3.4
@@ -30,20 +30,20 @@ Ionic App Entwickler: Michael Leu, Niklaus Tschirky, Sandro Zbinden
 - Upload mit Drag&Drop (E2E-Tests noch offen)
 
 ### Ausblick
-- Neues Logo und Namen (aufgrund Lizensbedingungen)
+- Neues Logo und Namen (aufgrund Lizenzbedingungen, Opensource Projekt)
 - Veröffentlichung in App Stores
 - Dokumentation (Trademarks, Copyright, Architecture Dokumente, Abstrakt)
 - Keyword und Data Feld Typen
 
 ### Fragen
-- CreateEntry ist aktuell ein Must-Kriterium. Für PIC und Imagic hat es eine tiefe Priorisierung, andere Features sind wichtiger → kann zu einem soll deklariert werden
+- CreateEntry ist aktuell ein Must-Kriterium. Für PIC und Imagic hat es eine tiefe Priorisierung, andere Features sind wichtiger → kann zu einem soll deklariert werden #446
 - Grundsätzliche Priorisierung in Ordnung
 - Verify EXIF Daten für Imagic und PIC höher priosieren
 - JPEG oder PNG von Kamera → Default weiterhin nutzen, für User keinen Unterschied
 
 ### Feedback / Input
 - Windows App Store → Aktuell nicht in unserem Fokus, sollte aber mithilfe des Framework möglich sein
-- TIF Format sollte auch möglich (aktuell noch begrenzt auf .jpg und .png)
+- TIF Format sollte auch möglich (aktuell noch begrenzt auf .jpg und .png) #444
 
 ### Bemerkungen
 Mithilfe des Burnup Diagrams wurde die Priorisierung mit allen Anwesenden besprochen und auch auf nicht erreichbare Aufgaben hingewiesen.  

--- a/docs/protocols/2017-06-30-presentation-sprint9-imagic_PICSystem.md
+++ b/docs/protocols/2017-06-30-presentation-sprint9-imagic_PICSystem.md
@@ -1,0 +1,53 @@
+# Kurzprotokoll Sprint 9 Review
+
+Freitag, 30.06.2017 10:00-10:45 bei PIC Systems AG, Glattbrugg
+
+## Teilnehmer
+
+PIC Systems: Adrian Martin, Michael Bachmann  
+Imagic: Urs Gomez, Patrick Bohren  
+Ionic App Entwickler: Michael Leu, Niklaus Tschirky, Sandro Zbinden
+
+## Traktanden
+- Abgeschlossene Aufgaben
+- In Bearbeitung
+- Ausblick
+- Fragen
+
+## Protokoll
+
+### Abgeschlossene Aufgaben
+- Dokumentation "Austausch von Logos/Grafiken"
+- Entfernen des Settings-Popover für vereinfachtes GUI und iOS-näheren Verhalten
+- Schiebe Knopf für Boolean Felder
+- Browserversion Kamerabutton entfernt und Fileupload mit Auswahlfenster hinzugefügt
+- Releasing überarbeitet (automatisches Generieren von Release Notes, definieren von einheitlichen Commitmessages, Autoupdate von Versionsnummer)
+- Upload Fehler bei langsamen Netzwerken durch Caddy Update gelöst
+- Lintregeln überarbeitet
+- Update auf neuste Ionic Version 3.4
+
+### In Bearbeitung
+- Upload mit Drag&Drop (E2E-Tests noch offen)
+
+### Ausblick
+- Neues Logo und Namen (aufgrund Lizensbedingungen)
+- Veröffentlichung in App Stores
+- Dokumentation (Trademarks, Copyright, Architecture Dokumente, Abstrakt)
+- Keyword und Data Feld Typen
+
+### Fragen
+- CreateEntry ist aktuell ein Must-Kriterium. Für PIC und Imagic hat es eine tiefe Priorisierung, andere Features sind wichtiger → kann zu einem soll deklariert werden
+- Grundsätzliche Priorisierung in Ordnung
+- Verify EXIF Daten für Imagic und PIC höher priosieren
+- JPEG oder PNG von Kamera → Default weiterhin nutzen, für User keinen Unterschied
+
+### Feedback / Input
+- Windows App Store → Aktuell nicht in unserem Fokus, sollte aber mithilfe des Framework möglich sein
+- TIF Format sollte auch möglich (aktuell noch begrenzt auf .jpg und .png)
+
+### Bemerkungen
+Mithilfe des Burnup Diagrams wurde die Priorisierung mit allen Anwesenden besprochen und auch auf nicht erreichbare Aufgaben hingewiesen.  
+Projektabschluss am 18. August mit Übergabe und Feedbackbesprechung → Einladung folgt
+
+### Nächster Termin
+14.07.2017 um 10:00


### PR DESCRIPTION
This protocol documents sprint 9 review with the stakeholder from PIC and Imagic.

This close #442 