### PR TITLE
fix(upload): allow image upload with enter key or native keyboard submit button

### DIFF
--- a/e2e/page-objects/upload-page-object.ts
+++ b/e2e/page-objects/upload-page-object.ts
@@ -1,5 +1,5 @@
 import { Helpers } from './../helpers/helpers';
-import { browser, element, by, ElementFinder, $, promise, ExpectedConditions } from 'protractor';
+import { browser, element, by, ElementFinder, $, promise, ExpectedConditions, protractor } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
 import { Observable } from 'rxjs/Observable';
 import { LoginPageObject } from './login-page-object';
@@ -61,6 +61,12 @@ export class UploadPageObject {
   clickIntoTextField(textField: ElementFinder) {
     Helpers.waitUntilElementIsReady(textField);
     textField.click();
+    browser.waitForAngular();
+  }
+
+  sendEnterKey(textField: ElementFinder) {
+    Helpers.waitUntilElementIsReady(textField);
+    textField.sendKeys(protractor.Key.ENTER);
     browser.waitForAngular();
   }
 

--- a/e2e/upload.e2e-spec.ts
+++ b/e2e/upload.e2e-spec.ts
@@ -55,6 +55,13 @@ describe('Upload E2E Test', () => {
     browser.wait(ExpectedConditions.visibilityOf(element(by.className('toast-message'))), Helpers.DEFAULT_WAIT_TIMEOUT);
   });
 
+  it('Should upload image with sending enter key', () => {
+    uploadPage.loadPage();
+    uploadPage.writeToTextField(uploadPage.bildNameFieldInput, 'e2e with enter Test');
+    uploadPage.sendEnterKey(uploadPage.bildNameFieldInput);
+    browser.wait(ExpectedConditions.visibilityOf(element(by.className('toast-message'))), Helpers.DEFAULT_WAIT_TIMEOUT);
+  });
+
   it('Should add fields and testing invalid inputs', () => {
     settingImageFieldsPageObject.loadPage();
     Helpers.toggleFieldSettings(settingImageFieldsPageObject.settingsImageFieldINTEGERFELDToggle);

--- a/src/pages/upload/upload.html
+++ b/src/pages/upload/upload.html
@@ -30,7 +30,7 @@
       <img class="scaled-image" [src]="domSanitizer.bypassSecurityTrustUrl(image.fileURI)" />
     </div>
     <ion-list *ngSwitchCase="'metadata'" id="id-list">
-      <form [formGroup]="fieldsForm">
+      <form [formGroup]="fieldsForm" (keydown.enter)="uploadPicture()" (ngSubmit)="uploadPicture()">
         <div *ngFor="let field of fields">
           <ion-item [ngSwitch]="field.type">
             <ion-label>{{field.name}}<span *ngIf="field.mandatory" class="mandatory" id="mandatory{{field.name}}"> *</span></ion-label>


### PR DESCRIPTION
Usually a from can be submitted by hitting the enter key in a browser or by pressing the native keyboard submit button on a mobile devices.  This change fix that in the upload page the form can be submitted in a standard way.

Closes #413 