### PR TITLE
build: add linter test to e2e files

### DIFF
--- a/e2e/archive-selection.e2e-spec.ts
+++ b/e2e/archive-selection.e2e-spec.ts
@@ -1,11 +1,10 @@
 import { Helpers } from './helpers/helpers';
 import { SettingArchivePageObject } from './page-objects/setting-archive-page-object';
-import { browser, element, by, ElementFinder, ExpectedConditions, protractor, $ } from 'protractor';
+import { browser, ExpectedConditions } from 'protractor';
 import { SettingsPageObject } from './page-objects/settings-page-object';
 import { SettingImageFieldsPageObject } from './page-objects/setting-image-field-page-object';
 import { LoginPageObject } from './page-objects/login-page-object';
 import { EntriesPageObject } from './page-objects/entries-page-object';
-import { UploadPageObject } from './page-objects/upload-page-object';
 
 describe('Archive Selection E2E Test', () => {
 
@@ -14,7 +13,6 @@ describe('Archive Selection E2E Test', () => {
   let loginPage = new LoginPageObject();
   let entriesPage = new EntriesPageObject();
   let settingsPage = new SettingsPageObject();
-  let uploadPage = new UploadPageObject();
   let settingImageFieldsPage = new SettingImageFieldsPageObject();
 
   beforeEach(function () {

--- a/e2e/login.e2e-spec.ts
+++ b/e2e/login.e2e-spec.ts
@@ -1,11 +1,10 @@
 import { LoginPageObject } from './page-objects/login-page-object';
-import { browser, element, by, ElementFinder } from 'protractor';
 
 let loginPage = new LoginPageObject();
 
 describe('Login E2E Test', () => {
 
-  var originalTimeout;
+  let originalTimeout;
 
   beforeEach(function () {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;

--- a/e2e/logout.e2e-spec.ts
+++ b/e2e/logout.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { SettingsPageObject } from './page-objects/settings-page-object';
-import { browser, element, by, ElementFinder, protractor, $, ExpectedConditions } from 'protractor';
+import { browser } from 'protractor';
 import { LoginPageObject } from './page-objects/login-page-object';
 
 describe('Logout E2E Test', () => {
@@ -36,12 +36,3 @@ describe('Logout E2E Test', () => {
     loginPage.getPasswordInputText().then(text => expect(text).toEqual(''));
   });
 });
-
-function waitUntilElementsAreClickable() {
-  browser.wait(ExpectedConditions.stalenessOf($('.click-block-active')));
-  browser.sleep(1000);
-}
-
-function waitUntilPageReady() {
-  browser.sleep(2000);
-}

--- a/e2e/page-objects/entries-page-object.ts
+++ b/e2e/page-objects/entries-page-object.ts
@@ -1,7 +1,7 @@
 import { Helpers } from './../helpers/helpers';
 import { LoginPageObject } from './login-page-object';
 import { SettingArchivePageObject } from './setting-archive-page-object';
-import { browser, element, by, ElementFinder, ElementArrayFinder } from 'protractor';
+import { browser, element, by, ElementFinder, ElementArrayFinder, ExpectedConditions } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
 
 export class EntriesPageObject {

--- a/e2e/page-objects/entries-page-object.ts
+++ b/e2e/page-objects/entries-page-object.ts
@@ -1,10 +1,8 @@
 import { Helpers } from './../helpers/helpers';
 import { LoginPageObject } from './login-page-object';
 import { SettingArchivePageObject } from './setting-archive-page-object';
-import { SettingArchivePage } from './../../src/pages/setting-archive/setting-archive';
-import { browser, element, by, ElementFinder, $, promise, ExpectedConditions, ElementArrayFinder } from 'protractor';
+import { browser, element, by, ElementFinder, ElementArrayFinder } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
-import { Observable } from 'rxjs/Observable';
 
 export class EntriesPageObject {
   settingsButton: ElementFinder = element(by.id('settingsButton'));

--- a/e2e/page-objects/login-page-object.ts
+++ b/e2e/page-objects/login-page-object.ts
@@ -1,7 +1,6 @@
 import { Helpers } from './../helpers/helpers';
-import { browser, element, by, ElementFinder, $, promise, ExpectedConditions } from 'protractor';
+import { browser, element, by, ElementFinder, promise, ExpectedConditions } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
-import { Observable } from 'rxjs/Observable';
 
 export class LoginPageObject {
   server: string = 'https://sinv-56028.edu.hsr.ch';

--- a/e2e/page-objects/setting-archive-page-object.ts
+++ b/e2e/page-objects/setting-archive-page-object.ts
@@ -1,7 +1,6 @@
 import { LoginPageObject } from './login-page-object';
-import { browser, element, by, ElementFinder, $, promise, ExpectedConditions } from 'protractor';
+import { element, by, ElementFinder, ExpectedConditions } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
-import { Observable } from 'rxjs/Observable';
 import { Helpers } from '../helpers/helpers';
 
 export class SettingArchivePageObject {

--- a/e2e/page-objects/setting-image-field-page-object.ts
+++ b/e2e/page-objects/setting-image-field-page-object.ts
@@ -1,7 +1,6 @@
 import { Helpers } from './../helpers/helpers';
-import { browser, element, by, ElementFinder, $, promise, ExpectedConditions, ElementArrayFinder } from 'protractor';
+import { browser, element, by, ElementFinder, ExpectedConditions, ElementArrayFinder } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
-import { Observable } from 'rxjs/Observable';
 import { SettingsPageObject } from './settings-page-object';
 
 export class SettingImageFieldsPageObject {

--- a/e2e/page-objects/settings-page-object.ts
+++ b/e2e/page-objects/settings-page-object.ts
@@ -1,7 +1,6 @@
 import { Helpers } from './../helpers/helpers';
-import { browser, element, by, ElementFinder, $, promise, ExpectedConditions } from 'protractor';
+import { element, by, ElementFinder } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
-import { Observable } from 'rxjs/Observable';
 import { EntriesPageObject } from './entries-page-object';
 
 export class SettingsPageObject {

--- a/e2e/page-objects/upload-page-object.ts
+++ b/e2e/page-objects/upload-page-object.ts
@@ -1,8 +1,6 @@
 import { Helpers } from './../helpers/helpers';
-import { browser, element, by, ElementFinder, $, promise, ExpectedConditions, protractor } from 'protractor';
+import { browser, element, by, ElementFinder, ExpectedConditions, protractor } from 'protractor';
 import 'rxjs/add/observable/fromPromise';
-import { Observable } from 'rxjs/Observable';
-import { LoginPageObject } from './login-page-object';
 import { EntriesPageObject } from './entries-page-object';
 
 export class UploadPageObject {

--- a/e2e/settings.e2e-spec.ts
+++ b/e2e/settings.e2e-spec.ts
@@ -1,9 +1,8 @@
 import { Helpers } from './helpers/helpers';
-import { browser, element, by, ElementFinder, ExpectedConditions, protractor, $ } from 'protractor';
+import { browser, ExpectedConditions} from 'protractor';
 import { SettingsPageObject } from './page-objects/settings-page-object';
 import { SettingImageFieldsPageObject } from './page-objects/setting-image-field-page-object';
 import { LoginPageObject } from './page-objects/login-page-object';
-import { EntriesPageObject } from './page-objects/entries-page-object';
 import { UploadPageObject } from './page-objects/upload-page-object';
 
 describe('Settings E2E Test', () => {
@@ -11,7 +10,6 @@ describe('Settings E2E Test', () => {
   let originalTimeout;
   let settingsPage = new SettingsPageObject();
   let loginPage = new LoginPageObject();
-  let entriesPage = new EntriesPageObject();
   let uploadPage = new UploadPageObject();
   let settingImageFieldsPage = new SettingImageFieldsPageObject();
 

--- a/e2e/upload.e2e-spec.ts
+++ b/e2e/upload.e2e-spec.ts
@@ -1,18 +1,13 @@
 import { Helpers } from './helpers/helpers';
-import { SettingImageFieldsPage } from './../src/pages/setting-image-fields/setting-image-fields';
-import { browser, element, by, ElementFinder, ExpectedConditions, protractor, $ } from 'protractor';
-import { SettingsPageObject } from './page-objects/settings-page-object';
+import { browser, element, by, ExpectedConditions } from 'protractor';
 import { SettingImageFieldsPageObject } from './page-objects/setting-image-field-page-object';
 import { LoginPageObject } from './page-objects/login-page-object';
-import { EntriesPageObject } from './page-objects/entries-page-object';
 import { UploadPageObject } from './page-objects/upload-page-object';
 
 describe('Upload E2E Test', () => {
 
   let originalTimeout;
-  let settingsPage = new SettingsPageObject();
   let loginPage = new LoginPageObject();
-  let entriesPage = new EntriesPageObject();
   let uploadPage = new UploadPageObject();
   let settingImageFieldsPageObject = new SettingImageFieldsPageObject();
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "ionic-app-scripts build",
     "ionic:build": "ionic-app-scripts build",
     "ionic:serve": "ionic-app-scripts serve",
-    "lint": "ionic-app-scripts lint --bailOnLintError true && tslint --config tslint-codelyzer.json --project tsconfig.json",
+    "lint": "tslint --config tslint.json --project ts-lintconfig.json && tslint --config tslint-codelyzer.json --project ts-lintconfig.json",
     "test": "karma start ./test-config/karma.conf.js",
     "test-coverage": "karma start ./test-config/karma.conf.js --coverage",
     "e2e": "npm run clean && npm run build && node node_modules/protractor/bin/webdriver-manager update && node node_modules/protractor/bin/protractor",

--- a/src/mocks/providers/transfer-blob-mock.ts
+++ b/src/mocks/providers/transfer-blob-mock.ts
@@ -3,19 +3,6 @@ import { Http, Headers, Response } from '@angular/http';
 import { FileUploadResultMock } from './transfer-mock';
 import 'rxjs/add/operator/toPromise';
 
-export class TransferBlobMock {
-  http: Http;
-
-  constructor(http: Http) {
-    this.http = http;
-  }
-
-  create() {
-    return new TransferBlobObjectMock(this.http);
-  }
-
-}
-
 export class TransferBlobObjectMock {
   http: Http;
 
@@ -33,6 +20,19 @@ export class TransferBlobObjectMock {
     result.headers = response.headers;
     result.responseCode = response.status;
     return result;
+  }
+
+}
+
+export class TransferBlobMock {
+  http: Http;
+
+  constructor(http: Http) {
+    this.http = http;
+  }
+
+  create() {
+    return new TransferBlobObjectMock(this.http);
   }
 
 }

--- a/src/mocks/providers/transfer-mock.ts
+++ b/src/mocks/providers/transfer-mock.ts
@@ -1,19 +1,5 @@
 import { FileUploadOptions, FileUploadResult } from '@ionic-native/transfer';
 
-export class TransferMock {
-  create() {
-    return new TransferObjectMock();
-  }
-}
-
-export class TransferObjectMock  {
-  upload(fileUrl: string, url: string, options?: FileUploadOptions, trustAllHosts?: boolean): Promise<FileUploadResult> {
-    return new Promise((resolve, reject) => {
-      resolve(new FileUploadResultMock());
-    });
-  }
-}
-
 export class FileUploadResultMock {
   bytesSent: number;
   responseCode: number;
@@ -21,4 +7,18 @@ export class FileUploadResultMock {
   headers: {
     [s: string]: any;
   };
+}
+
+export class TransferObjectMock {
+  upload(fileUrl: string, url: string, options?: FileUploadOptions, trustAllHosts?: boolean): Promise<FileUploadResult> {
+    return new Promise((resolve, reject) => {
+      resolve(new FileUploadResultMock());
+    });
+  }
+}
+
+export class TransferMock {
+  create() {
+    return new TransferObjectMock();
+  }
 }

--- a/ts-lintconfig.json
+++ b/ts-lintconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "target": "es5"
+  },
+  "include": [
+    "src/**/*.ts",
+    "e2e"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+  "compileOnSave": false,
+  "atom": {
+    "rewriteTsconfig": false
+  }
+}


### PR DESCRIPTION
To ensure code consistency also check e2e test files with linter configuration. This removes the ionic app script lint checks as the current version is slow and the stable version uses outdated tslint version.

Closes #416 