### PR TITLE
build: extend lint rule "whitespace"

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -65,7 +65,15 @@
       true
     ],
     "whitespace": [
-      true
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-module",
+      "check-separator",
+      "check-type",
+      "check-typecast",
+      "check-preblock"
     ],
     "no-var-keyword": true
   }


### PR DESCRIPTION
At least `check-type` got lost when we switched from the ionic app lint rules to our own. This activates all whitespace lint options.