### PR TITLE
build: add lint rule  "restrict-plus-operands" and "prefer-template"

### DIFF
--- a/e2e/helpers/helpers.ts
+++ b/e2e/helpers/helpers.ts
@@ -39,7 +39,7 @@ export class Helpers {
 
   static sendDragEnterEventToElement(id: string): void {
     browser.executeScript(`let dragEnterEvent = new DragEvent("dragenter");
-      Object.defineProperty(dragEnterEvent.constructor.prototype, "dataTransfer", { value: {} });'
+      Object.defineProperty(dragEnterEvent.constructor.prototype, "dataTransfer", { value: {} });
       document.getElementById("${id}").dispatchEvent(dragEnterEvent)`);
   }
 

--- a/e2e/helpers/helpers.ts
+++ b/e2e/helpers/helpers.ts
@@ -32,26 +32,26 @@ export class Helpers {
   }
 
   static removeEventlistenerFromElement(id: string): void {
-    browser.executeScript('let changeElement = document.getElementById("' + id + '");'
-      + 'let cloneElement = changeElement.cloneNode();'
-      + 'changeElement.parentNode.replaceChild(cloneElement, changeElement);');
+    browser.executeScript(`let changeElement = document.getElementById("${id}");
+      let cloneElement = changeElement.cloneNode();
+      changeElement.parentNode.replaceChild(cloneElement, changeElement);`);
   }
 
   static sendDragEnterEventToElement(id: string): void {
-    browser.executeScript('let dragEnterEvent = new DragEvent("dragenter");'
-      + 'Object.defineProperty(dragEnterEvent.constructor.prototype, "dataTransfer", { value: {} });'
-      + 'document.getElementById("' + id + '").dispatchEvent(dragEnterEvent)');
+    browser.executeScript(`let dragEnterEvent = new DragEvent("dragenter");
+      Object.defineProperty(dragEnterEvent.constructor.prototype, "dataTransfer", { value: {} });'
+      document.getElementById("${id}").dispatchEvent(dragEnterEvent)`);
   }
 
   static sendDragLeaveEventToElement(id: string): void {
-    browser.executeScript('let dragLeaveEvent = new DragEvent("dragleave");'
-      + 'document.getElementById("' + id + '").dispatchEvent(dragLeaveEvent)');
+    browser.executeScript(`let dragLeaveEvent = new DragEvent("dragleave");
+      document.getElementById("${id}").dispatchEvent(dragLeaveEvent)`);
   }
 
   static sendDragDropEventToElement(sourceFileInputId: string, targetId: string): void {
-    browser.executeScript('let dropEvent = new DragEvent("drop");'
-      + 'Object.defineProperty(dropEvent.constructor.prototype, "dataTransfer", { value: {} });'
-      + 'dropEvent.dataTransfer.files = document.getElementById("' + sourceFileInputId + '").files;'
-      + 'document.getElementById("' + targetId + '").dispatchEvent(dropEvent)');
+    browser.executeScript(`let dropEvent = new DragEvent("drop");
+      Object.defineProperty(dropEvent.constructor.prototype, "dataTransfer", { value: {} });
+      dropEvent.dataTransfer.files = document.getElementById("${sourceFileInputId}").files;
+      document.getElementById("${targetId}").dispatchEvent(dropEvent)`);
   }
 }

--- a/src/mocks/ims-backend-mock.ts
+++ b/src/mocks/ims-backend-mock.ts
@@ -48,7 +48,7 @@ export class ImsBackendMock extends MockBackend {
   public tokensUrl: string = this.licenseUrl + '/tokens';
   public tokenLoadingUrl: string = this.tokensUrl + '/ABCDE';
   public filterId: number = 40;
-  public filterResourceUrl: string = this.entriesUrl + '/' + this.filterId;
+  public filterResourceUrl: string = `${this.entriesUrl}/${this.filterId}`;
   public version: string = 'V17Q1';
   public versionResponse: any = { version: this.version };
   public tokenName: string = 'EDFC';
@@ -98,7 +98,7 @@ export class ImsBackendMock extends MockBackend {
     this.connections.subscribe((connection) => {
       if (!connection.request.url.startsWith(this.baseUrl)) {
         connection.mockError(new Error('Wrong Url'));
-      } else if (connection.request.headers.get('authorization') !== ('Basic ' + btoa(this.credential.username + ':' + this.credential.password))) {
+      } else if (connection.request.headers.get('authorization') !== ('Basic ' + btoa(`${this.credential.username}:${this.credential.password}`))) {
         connection.mockError(this.unauthorizedResponse);
       } else if (connection.request.url.endsWith(this.entryPointUrl) && connection.request.method === RequestMethod.Get) {
         connection.mockRespond(new EntryPointResponse([new Link('license', this.licenseUrl), new Link('info', this.infoUrl), new Link('entries', this.entriesUrl), new Link('models', this.modelsUrl)]));
@@ -133,7 +133,7 @@ export class ImsBackendMock extends MockBackend {
           body: this.versionResponse
         })));
       } else {
-        connection.mockError(new Error('No handling for: ' + connection.request.url));
+        connection.mockError(new Error(`No handling for: ${connection.request.url}`));
       }
     });
   }

--- a/src/models/errors/ims-server-connection-error.ts
+++ b/src/models/errors/ims-server-connection-error.ts
@@ -2,7 +2,7 @@ import { ImsError } from './ims-error';
 export class ImsServerConnectionError extends ImsError {
 
   constructor(server: string, err: any) {
-    super('Verbindung zum IMS Rest Server ' + server + ' nicht möglich.', err);
+    super(`Verbindung zum IMS Rest Server ${server} nicht möglich.`, err);
     Object.setPrototypeOf(this, ImsServerConnectionError.prototype);
   }
 }

--- a/src/models/ims-file-upload-headers.ts
+++ b/src/models/ims-file-upload-headers.ts
@@ -7,6 +7,6 @@ export class ImsFileUploadHeaders extends ImsHeaders {
   constructor(credential: Credential, token: Token, fileName: string) {
     super(credential, token);
     this.set('Content-Type', 'application/octet-stream');
-    this.set('Content-Disposition', 'attachment; filename="' + fileName + '"');
+    this.set('Content-Disposition', `attachment; filename="${fileName}"`);
   }
 }

--- a/src/models/ims-headers.ts
+++ b/src/models/ims-headers.ts
@@ -8,7 +8,7 @@ export class ImsHeaders extends Headers {
     super();
     this.append('Content-Type', 'application/json');
     this.append('Allow-Control-Allow-Origin', '*');
-    this.append('Authorization', 'Basic ' + btoa(credential.username + ':' + credential.password));
+    this.append('Authorization', 'Basic ' + btoa(`${credential.username}:${credential.password}`));
     if (token) {
       this.append('ims-rest-token', token.token);
     }

--- a/tslint.json
+++ b/tslint.json
@@ -93,7 +93,7 @@
     ],
     "only-arrow-functions": [true],
     "restrict-plus-operands": true,
-    "prefer-template": [true, "allow-single-concat"]
+    "prefer-template": [true, "allow-single-concat"],
     "prefer-for-of": true,
     "unified-signatures": true,
     "no-duplicate-super": true,

--- a/tslint.json
+++ b/tslint.json
@@ -91,6 +91,8 @@
       "parameter",
       "member-variable-declaration"
     ],
-    "only-arrow-functions": [true]
+    "only-arrow-functions": [true],
+    "restrict-plus-operands": true,
+    "prefer-template": [true, "allow-single-concat"]
   }
 }


### PR DESCRIPTION
Using a template as a workaround when concatenating two different types in ImsBackendMock.