### PR TITLE
build: add lint rule "strict-boolean-expressions"

### DIFF
--- a/src/mocks/drag-event-mock.ts
+++ b/src/mocks/drag-event-mock.ts
@@ -47,7 +47,7 @@ export class DragEventMock implements DragEvent {
 
   constructor(type: string, currentTarget?: Element) {
     this.type = type;
-    if (!currentTarget) {
+    if (currentTarget === undefined) {
       currentTarget = document.createElement('div');
       currentTarget.id = 'a1';
     }

--- a/src/mocks/mocks.ts
+++ b/src/mocks/mocks.ts
@@ -169,7 +169,7 @@ export class StorageMock {
   }
 
   public get(key: string): Promise<string> {
-    return Promise.resolve(this.store[key]);
+    return Promise.resolve(key in this.store? this.store[key]: null);
   }
 
   public set(key: string, value: string): Promise<{}> {

--- a/src/models/drag-event-counter.ts
+++ b/src/models/drag-event-counter.ts
@@ -28,7 +28,7 @@ export class DragEventCounter {
   }
 
   private ensureInitialisation(id: string): void {
-    if (!this.dragEventCountMap[id]) {
+    if (!(id in this.dragEventCountMap)) {
       this.dragEventCountMap[id] = 0;
     }
   }

--- a/src/models/ims-headers.ts
+++ b/src/models/ims-headers.ts
@@ -9,7 +9,7 @@ export class ImsHeaders extends Headers {
     this.append('Content-Type', 'application/json');
     this.append('Allow-Control-Allow-Origin', '*');
     this.append('Authorization', 'Basic ' + btoa(`${credential.username}:${credential.password}`));
-    if (token) {
+    if (token !== null) {
       this.append('ims-rest-token', token.token);
     }
   }

--- a/src/pages/entries/entries.spec.ts
+++ b/src/pages/entries/entries.spec.ts
@@ -328,7 +328,7 @@ describe('Page: Entries', () => {
     const event: DragEvent = new DragEventMock('drop');
     const parentImageEntryId = '1';
     const entryTitle = 'title';
-    spyOn(browserFileuploadSelectorService, 'getImageFromFileDrop').and.returnValue(null);
+    spyOn(browserFileuploadSelectorService, 'getImageFromFileDrop').and.returnValue(undefined);
     spyOn(page, 'pushToUploadPageWithPicture').and.callThrough();
     page.receiveDrop(event, parentImageEntryId, entryTitle);
     expect(page.pushToUploadPageWithPicture).toHaveBeenCalledTimes(0);

--- a/src/pages/entries/entries.ts
+++ b/src/pages/entries/entries.ts
@@ -115,7 +115,7 @@ export class EntriesPage {
 
   fileSelected(event: any, parentImageEntryId: string, entryTitle: string): void {
     const selectedImage: Image = this.browserFileuploadSelectorService.getImageFromFilePicker(event);
-    if (selectedImage) {
+    if (selectedImage !== undefined) {
       this.pushToUploadPageWithPicture(selectedImage, parentImageEntryId, entryTitle);
     }
   }
@@ -127,7 +127,7 @@ export class EntriesPage {
 
   receiveDrop(event: DragEvent, parentImageEntryId: string, entryTitle: string): void {
     const selectedImage: Image = this.browserFileuploadSelectorService.getImageFromFileDrop(event);
-    if (selectedImage) {
+    if (selectedImage !== undefined) {
       const element: Element = (event.currentTarget as Element);
       element.classList.remove('drag');
       this.pushToUploadPageWithPicture(selectedImage, parentImageEntryId, entryTitle);

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -56,7 +56,7 @@ export class LoginPage {
   }
 
   navigateAfterLogin(filter: Filter): void {
-    if (filter) {
+    if (filter !== null) {
       this.authService.setArchive(filter);
       this.navCtrl.setRoot(EntriesPage);
     } else {

--- a/src/pages/upload/upload.spec.ts
+++ b/src/pages/upload/upload.spec.ts
@@ -296,7 +296,7 @@ describe('Page: Upload', () => {
     const event: DragEvent = new DragEventMock('drop');
     const oldImage = new Image('picture.jpg', '/my/picture.jpg');
     page.image = oldImage;
-    spyOn(browserFileuploadSelectorService, 'getImageFromFileDrop').and.returnValue(null);
+    spyOn(browserFileuploadSelectorService, 'getImageFromFileDrop').and.returnValue(undefined);
     page.receiveDrop(event);
     expect(page.image).toEqual(oldImage);
   }));

--- a/src/pages/upload/upload.ts
+++ b/src/pages/upload/upload.ts
@@ -144,7 +144,7 @@ export class UploadPage {
 
   fileSelected(event: any): void {
     const selectedImage: Image = this.browserFileuploadSelectorService.getImageFromFilePicker(event);
-    if (selectedImage) {
+    if (selectedImage !== undefined) {
       this.image = selectedImage;
     }
   }
@@ -156,7 +156,7 @@ export class UploadPage {
   receiveDrop(event: DragEvent): void {
     this.showDragOverlay = false;
     const selectedImage: Image = this.browserFileuploadSelectorService.getImageFromFileDrop(event);
-    if (selectedImage) {
+    if (selectedImage !== undefined) {
       this.image = selectedImage;
     }
   }

--- a/src/providers/browser-fileupload-selector-service.ts
+++ b/src/providers/browser-fileupload-selector-service.ts
@@ -9,7 +9,7 @@ export class BrowserFileuploadSelectorService {
 
   getImageFromFilePicker(event: any): Image | undefined {
     const image = this.getImageFromFileList(event.target.files);
-    if (image) {
+    if (image !== undefined) {
       event.target.value = null;
     }
     return image;

--- a/tslint.json
+++ b/tslint.json
@@ -108,6 +108,7 @@
     "arrow-return-shorthand": true,
     "typeof-compare": true,
     "no-object-literal-type-assertion": true,
-    "no-magic-numbers": true
+    "no-magic-numbers": true,
+    "strict-boolean-expressions": true
   }
 }


### PR DESCRIPTION
StorageMock.get() on a undefined key now needs to return null to match the behaviour of ionic storage.


