### PR TITLE
build: link to definition of done for commit guide lines in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 All notable changes to this project will be documented in this file. See  [Definition of Done](CONTRIBUTING.md) for commit guidelines.
 
-<a name="0.8.2"></a>
-## [0.8.2](https://github.com/IMSmobile/app/compare/0.8.1...v0.8.2) (2017-07-14)
-
-
-
-<a name="0.8.2"></a>
-## [0.8.2](https://github.com/IMSmobile/app/compare/0.8.1...v0.8.2) (2017-07-14)
-
-
-
 <a name="0.8.1"></a>
 ## [0.8.1](https://github.com/IMSmobile/app/compare/0.8.0...v0.8.1) (2017-07-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+All notable changes to this project will be documented in this file. See  [Definition of Done](CONTRIBUTING.md) for commit guidelines.
+
+<a name="0.8.2"></a>
+## [0.8.2](https://github.com/IMSmobile/app/compare/0.8.1...v0.8.2) (2017-07-14)
+
+
+
+<a name="0.8.2"></a>
+## [0.8.2](https://github.com/IMSmobile/app/compare/0.8.1...v0.8.2) (2017-07-14)
+
+
 
 <a name="0.8.1"></a>
 ## [0.8.1](https://github.com/IMSmobile/app/compare/0.8.0...v0.8.1) (2017-07-14)

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -8,6 +8,7 @@ const standardVersion = require('standard-version');
 const packageJsonFile = path.resolve(__dirname, '../package.json');
 const configXmlFile = path.resolve(__dirname, '../config.xml');
 const loginTsFile = path.resolve(__dirname, '../src/pages/login/login.ts');
+const changelogFile = path.resolve(__dirname, '../CHANGELOG.md');
 var packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'utf8'));
 
 var versionBefore = packageJson['version'];
@@ -19,6 +20,9 @@ standardVersion({ 'skip': { 'commit': true, 'tag': true } }).then(function succ(
   console.info(chalk.green(figures.tick) + ' bumping version in config.xml from ' + chalk.bold(versionBefore) + ' to ' + chalk.bold(newVersion));
   replaceInFile(loginTsFile, 'version: string = \'' + versionBefore + '\'', 'version: string = \'' + newVersion + '\'');
   console.info(chalk.green(figures.tick) + ' bumping version in login.ts from ' + chalk.bold(versionBefore) + ' to ' + chalk.bold(newVersion));
+  replaceInFile(changelogFile, '[standard-version](https://github.com/conventional-changelog/standard-version)', ' [Definition of Done](CONTRIBUTING.md)'); 
+  console.info(chalk.green(figures.tick) + ' link to definition of done for commit guide lines in CHANGELOG.nd');
+
   printTodoCommand('git add package.json config.xml src/pages/login/login.ts CHANGELOG.md', 'after checking local changes');
   printTodoCommand('git commit -m "' + "release: " + newVersion + '"', 'to commit local changes');
   printTodoCommand('git tag -a -m "' + "release: " + newVersion + '" ' + newVersion, 'to create new tag');


### PR DESCRIPTION
The npm library standard-version references to the commit guidelines defined in standard-version. This project has it's own commit guidelines thus we should reference those.

This closes #448 