### PR TITLE
test: remove compileComponents and async from all specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "html-loader": "^0.4.5",
     "ionic": "^3.0.0",
     "istanbul-instrumenter-loader": "^2.0.0",
-    "jasmine": "^2.6.0",
+    "jasmine": "2.5.2",
     "jasmine-spec-reporter": "^4.0.0",
     "karma": "^1.7.0",
     "karma-chrome-launcher": "^2.0.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { IonicModule } from 'ionic-angular';
 
 import { SplashScreen } from '@ionic-native/splash-screen';
@@ -10,7 +10,7 @@ describe('MobileApp Component', () => {
   let fixture;
   let component;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [MobileClient],
       imports: [
@@ -21,7 +21,7 @@ describe('MobileApp Component', () => {
         SplashScreen
       ]
     });
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MobileClient);

--- a/src/components/ims-field-selection/ims-field-selection.spec.ts
+++ b/src/components/ims-field-selection/ims-field-selection.spec.ts
@@ -12,7 +12,7 @@ describe('Component: ImsFieldSelectionComponent', () => {
   let fixture: ComponentFixture<ImsFieldSelectionComponent>;
   let component: ImsFieldSelectionComponent;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -32,12 +32,12 @@ describe('Component: ImsFieldSelectionComponent', () => {
         { provide: Platform, useClass: PlatformMock },
       ],
       imports: [FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(ImsFieldSelectionComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+
+    fixture = TestBed.createComponent(ImsFieldSelectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/components/ims-field-selection/ims-field-selection.spec.ts
+++ b/src/components/ims-field-selection/ims-field-selection.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { App, Config, DomController, Form, GestureController, Haptic, IonicModule, Keyboard, NavController, Platform } from 'ionic-angular';
@@ -13,11 +13,8 @@ describe('Component: ImsFieldSelectionComponent', () => {
   let component: ImsFieldSelectionComponent;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [ImsFieldSelectionComponent],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, SettingService, Haptic,
         GestureController, ImsBackendMock, BaseRequestOptions,

--- a/src/pages/entries/entries.spec.ts
+++ b/src/pages/entries/entries.spec.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:max-file-line-count */
-import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { Camera } from '@ionic-native/camera';
@@ -38,11 +38,8 @@ describe('Page: Entries', () => {
   let page: EntriesPage;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [EntriesPage],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, EntriesService, LoadingController,
         AuthService, ImsService, TokenService, ImsBackendMock, BaseRequestOptions, Camera, GestureController,
@@ -57,7 +54,6 @@ describe('Page: Entries', () => {
         { provide: LoadingController, useClass: LoadingMock },
         { provide: PopoverController, useClass: PopoverControllerMock },
         { provide: Storage, useClass: StorageMock },
-
         {
           provide: Http,
           useFactory: (imsBackendMock, options) =>

--- a/src/pages/entries/entries.spec.ts
+++ b/src/pages/entries/entries.spec.ts
@@ -37,7 +37,7 @@ describe('Page: Entries', () => {
   let fixture: ComponentFixture<EntriesPage>;
   let page: EntriesPage;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -66,12 +66,12 @@ describe('Page: Entries', () => {
         },
       ],
       imports: [HttpModule, FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(EntriesPage);
-      page = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+
+    fixture = TestBed.createComponent(EntriesPage);
+    page = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/pages/login/login.spec.ts
+++ b/src/pages/login/login.spec.ts
@@ -26,7 +26,7 @@ describe('Page: Login', () => {
   let fixture: ComponentFixture<LoginPage>;
   let page: LoginPage;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -52,12 +52,12 @@ describe('Page: Login', () => {
         { provide: Storage, useClass: StorageMock },
       ],
       imports: [HttpModule, FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(LoginPage);
-      page = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+
+    fixture = TestBed.createComponent(LoginPage);
+    page = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/pages/login/login.spec.ts
+++ b/src/pages/login/login.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { Storage } from '@ionic/storage';
@@ -27,11 +27,8 @@ describe('Page: Login', () => {
   let page: LoginPage;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [LoginPage],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, LoadingController, AuthService,
         ImsService, ImsBackendMock, BaseRequestOptions, LoadingService, AlertService, SettingService,

--- a/src/pages/setting-archive/setting-archive.spec.ts
+++ b/src/pages/setting-archive/setting-archive.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { Storage } from '@ionic/storage';
@@ -26,11 +26,8 @@ describe('Page: Archive Settings', () => {
   let page: SettingArchivePage;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [SettingArchivePage],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, LoadingController, AuthService, ImsService,
         UploadService, ImsBackendMock, BaseRequestOptions, LoadingService, GestureController, SettingService,

--- a/src/pages/setting-archive/setting-archive.spec.ts
+++ b/src/pages/setting-archive/setting-archive.spec.ts
@@ -25,7 +25,7 @@ describe('Page: Archive Settings', () => {
   let fixture: ComponentFixture<SettingArchivePage>;
   let page: SettingArchivePage;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -48,12 +48,12 @@ describe('Page: Archive Settings', () => {
         },
       ],
       imports: [HttpModule, FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(SettingArchivePage);
-      page = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+
+    fixture = TestBed.createComponent(SettingArchivePage);
+    page = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/pages/setting-entries-fields/setting-entries-fields.spec.ts
+++ b/src/pages/setting-entries-fields/setting-entries-fields.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { Storage } from '@ionic/storage';
@@ -24,11 +24,8 @@ describe('Page: Parent Entries Settings Fields', () => {
   let page: SettingEntriesFieldsPage;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [SettingEntriesFieldsPage, ImsFieldSelectionComponent],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, SettingService, Haptic,
         GestureController, LoadingService, AuthService, ImsBackendMock, BaseRequestOptions, ImsService, ModelService,

--- a/src/pages/setting-entries-fields/setting-entries-fields.spec.ts
+++ b/src/pages/setting-entries-fields/setting-entries-fields.spec.ts
@@ -23,7 +23,7 @@ describe('Page: Parent Entries Settings Fields', () => {
   let fixture: ComponentFixture<SettingEntriesFieldsPage>;
   let page: SettingEntriesFieldsPage;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -46,12 +46,12 @@ describe('Page: Parent Entries Settings Fields', () => {
         { provide: Storage, useClass: StorageMock }
       ],
       imports: [FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(SettingEntriesFieldsPage);
-      page = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+
+    fixture = TestBed.createComponent(SettingEntriesFieldsPage);
+    page = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/pages/setting-image-fields/setting-image-fields.spec.ts
+++ b/src/pages/setting-image-fields/setting-image-fields.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BaseRequestOptions, Http } from '@angular/http';
 import { Storage } from '@ionic/storage';
@@ -24,11 +24,8 @@ describe('Page: Image Settings Fields', () => {
   let page: SettingImageFieldsPage;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [SettingImageFieldsPage, ImsFieldSelectionComponent],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, SettingService, Haptic,
         GestureController, LoadingService, AuthService, ImsBackendMock, BaseRequestOptions, ImsService, ModelService,

--- a/src/pages/setting-image-fields/setting-image-fields.spec.ts
+++ b/src/pages/setting-image-fields/setting-image-fields.spec.ts
@@ -23,7 +23,7 @@ describe('Page: Image Settings Fields', () => {
   let fixture: ComponentFixture<SettingImageFieldsPage>;
   let page: SettingImageFieldsPage;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -46,12 +46,12 @@ describe('Page: Image Settings Fields', () => {
         { provide: Storage, useClass: StorageMock }
       ],
       imports: [FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(SettingImageFieldsPage);
-      page = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+
+    fixture = TestBed.createComponent(SettingImageFieldsPage);
+    page = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/pages/settings/settings.spec.ts
+++ b/src/pages/settings/settings.spec.ts
@@ -20,11 +20,8 @@ describe('Page: Settings', () => {
   let page: SettingsPage;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [SettingsPage],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, SettingService, Haptic, GestureController, AuthService, ImsBackendMock, BaseRequestOptions, ImsService,
         { provide: App, useClass: AppMock },
@@ -41,6 +38,7 @@ describe('Page: Settings', () => {
       ],
       imports: [FormsModule, IonicModule, ReactiveFormsModule]
     });
+
     fixture = TestBed.createComponent(SettingsPage);
     page = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pages/settings/settings.spec.ts
+++ b/src/pages/settings/settings.spec.ts
@@ -19,7 +19,7 @@ describe('Page: Settings', () => {
   let fixture: ComponentFixture<SettingsPage>;
   let page: SettingsPage;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -40,12 +40,11 @@ describe('Page: Settings', () => {
         },
       ],
       imports: [FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(SettingsPage);
-      page = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+    fixture = TestBed.createComponent(SettingsPage);
+    page = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/pages/upload/upload.spec.ts
+++ b/src/pages/upload/upload.spec.ts
@@ -40,7 +40,7 @@ describe('Page: Upload', () => {
   let fixture: ComponentFixture<UploadPage>;
   let page: UploadPage;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
 
     TestBed.configureTestingModule({
 
@@ -67,12 +67,12 @@ describe('Page: Upload', () => {
         },
       ],
       imports: [HttpModule, FormsModule, IonicModule, ReactiveFormsModule]
-    }).compileComponents().then(() => {
-      fixture = TestBed.createComponent(UploadPage);
-      page = fixture.componentInstance;
-      fixture.detectChanges();
     });
-  }));
+
+    fixture = TestBed.createComponent(UploadPage);
+    page = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/pages/upload/upload.spec.ts
+++ b/src/pages/upload/upload.spec.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:max-file-line-count */
-import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BaseRequestOptions, Http, HttpModule, Response, ResponseOptions } from '@angular/http';
 import { Camera } from '@ionic-native/camera';
@@ -41,11 +41,8 @@ describe('Page: Upload', () => {
   let page: UploadPage;
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
-
       declarations: [UploadPage],
-
       providers: [
         App, DomController, Form, Keyboard, NavController, LoadingController, AlertController, AuthService, ImsService,
         TokenService, UploadService, ImsBackendMock, BaseRequestOptions, CameraService, Camera, LoadingService, AlertService, Transfer, ModelService, GestureController, SettingService,

--- a/src/providers/alert-service.spec.ts
+++ b/src/providers/alert-service.spec.ts
@@ -1,19 +1,17 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { AlertController } from 'ionic-angular';
 import { AlertMock } from '../mocks/mocks';
 import { AlertService } from './alert-service';
 
 describe('Provider: AlertService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
       providers: [AlertService, { provide: AlertController, useClass: AlertMock }],
       imports: []
     });
-  }));
+  });
 
   it('Should create error with correct attributes', inject([AlertService, AlertController], (alertService: AlertService, alertController: AlertController) => {
     const errorText = 'FAIL';

--- a/src/providers/alert-service.spec.ts
+++ b/src/providers/alert-service.spec.ts
@@ -12,7 +12,7 @@ describe('Provider: AlertService', () => {
       declarations: [],
       providers: [AlertService, { provide: AlertController, useClass: AlertMock }],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('Should create error with correct attributes', inject([AlertService, AlertController], (alertService: AlertService, alertController: AlertController) => {

--- a/src/providers/auth-service.spec.ts
+++ b/src/providers/auth-service.spec.ts
@@ -32,7 +32,7 @@ describe('Provider: AuthService', () => {
         }
       ],
       imports: [HttpModule]
-    }).compileComponents();
+    });
   }));
 
   it('Should store credentials if succeed', inject([AuthService, ImsBackendMock], (authService: AuthService, imsBackendMock: ImsBackendMock) => {

--- a/src/providers/auth-service.spec.ts
+++ b/src/providers/auth-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { Storage } from '@ionic/storage';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
@@ -11,12 +11,9 @@ import { SettingService } from './setting-service';
 
 describe('Provider: AuthService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
-
       providers: [
         AuthService,
         ImsService,
@@ -33,7 +30,7 @@ describe('Provider: AuthService', () => {
       ],
       imports: [HttpModule]
     });
-  }));
+  });
 
   it('Should store credentials if succeed', inject([AuthService, ImsBackendMock], (authService: AuthService, imsBackendMock: ImsBackendMock) => {
     const credential = imsBackendMock.credential;

--- a/src/providers/browser-container-upload-service.spec.ts
+++ b/src/providers/browser-container-upload-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, HttpModule, RequestOptions } from '@angular/http';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
 import { Image } from './../models/image';
@@ -7,7 +7,7 @@ import { BrowserContainerUploadService } from './browser-container-upload-servic
 
 describe('Provider: BrowserContainerUploadService', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [
@@ -23,7 +23,7 @@ describe('Provider: BrowserContainerUploadService', () => {
       ],
       imports: [HttpModule]
     });
-  }));
+  });
 
   it('Should post to a container', inject([BrowserContainerUploadService, Http, ImsBackendMock], (browserContainerUploadService: BrowserContainerUploadService, http: Http, imsBackendMock: ImsBackendMock) => {
     const file = new File([new Blob([])], 'a.jpg');

--- a/src/providers/browser-container-upload-service.spec.ts
+++ b/src/providers/browser-container-upload-service.spec.ts
@@ -22,7 +22,7 @@ describe('Provider: BrowserContainerUploadService', () => {
         }
       ],
       imports: [HttpModule]
-    }).compileComponents();
+    });
   }));
 
   it('Should post to a container', inject([BrowserContainerUploadService, Http, ImsBackendMock], (browserContainerUploadService: BrowserContainerUploadService, http: Http, imsBackendMock: ImsBackendMock) => {

--- a/src/providers/browser-fileupload-selector-service.spec.ts
+++ b/src/providers/browser-fileupload-selector-service.spec.ts
@@ -12,7 +12,7 @@ describe('Provider: BrowserFileuploadSelectorService', () => {
         BrowserFileuploadSelectorService
       ],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('should return an image when an event from file picker is called', inject([BrowserFileuploadSelectorService], (browserFileuploadSelectorService: BrowserFileuploadSelectorService) => {

--- a/src/providers/browser-fileupload-selector-service.spec.ts
+++ b/src/providers/browser-fileupload-selector-service.spec.ts
@@ -1,11 +1,11 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { ImsFileTypeError } from './../models/errors/ims-file-type-error';
 import { Image } from './../models/image';
 import { BrowserFileuploadSelectorService } from './browser-fileupload-selector-service';
 
 describe('Provider: BrowserFileuploadSelectorService', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [
@@ -13,7 +13,7 @@ describe('Provider: BrowserFileuploadSelectorService', () => {
       ],
       imports: []
     });
-  }));
+  });
 
   it('should return an image when an event from file picker is called', inject([BrowserFileuploadSelectorService], (browserFileuploadSelectorService: BrowserFileuploadSelectorService) => {
     const fileName = 'file.jpg';

--- a/src/providers/browser-setting-service.spec.ts
+++ b/src/providers/browser-setting-service.spec.ts
@@ -11,7 +11,7 @@ describe('Provider: BrowserSettingService', () => {
       declarations: [],
       providers: [{ provide: SettingService, useClass: BrowserSettingService }, { provide: Storage, useClass: StorageMock }],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('picture from camera is disabled', (inject([SettingService, Storage], (settingService: SettingService) => {

--- a/src/providers/browser-setting-service.spec.ts
+++ b/src/providers/browser-setting-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { Storage } from '@ionic/storage';
 import { StorageMock } from '../mocks/mocks';
 import { BrowserSettingService } from './browser-setting-service';
@@ -6,13 +6,13 @@ import { SettingService } from './setting-service';
 
 describe('Provider: BrowserSettingService', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [{ provide: SettingService, useClass: BrowserSettingService }, { provide: Storage, useClass: StorageMock }],
       imports: []
     });
-  }));
+  });
 
   it('picture from camera is disabled', (inject([SettingService, Storage], (settingService: SettingService) => {
     expect(settingService.isPictureFromCameraEnabled()).toBeFalsy();

--- a/src/providers/camera-service.spec.ts
+++ b/src/providers/camera-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { Camera } from '@ionic-native/camera';
 import { AlertController } from 'ionic-angular';
 import { AlertMock } from './../mocks/mocks';
@@ -9,12 +9,9 @@ import { CameraService } from './camera-service';
 
 describe('Provider: CameraService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
-
       providers: [
         CameraService,
         AlertService,
@@ -23,7 +20,7 @@ describe('Provider: CameraService', () => {
       ],
       imports: []
     });
-  }));
+  });
 
   it('returns observable from camera with response on success', inject([CameraService, Camera, AlertService], (cameraService: CameraService, camera: Camera, alertService: AlertService) => {
     const imageSrc = '/my/picture.jpg';

--- a/src/providers/camera-service.spec.ts
+++ b/src/providers/camera-service.spec.ts
@@ -22,7 +22,7 @@ describe('Provider: CameraService', () => {
         { provide: AlertController, useClass: AlertMock },
       ],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('returns observable from camera with response on success', inject([CameraService, Camera, AlertService], (cameraService: CameraService, camera: Camera, alertService: AlertService) => {

--- a/src/providers/container-upload-service.spec.ts
+++ b/src/providers/container-upload-service.spec.ts
@@ -17,7 +17,7 @@ describe('Provider: ContainerUploadService', () => {
         { provide: Transfer, useClass: TransferMock },
       ],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('Should post to a container', inject([ContainerUploadService, Transfer, ImsBackendMock], (containerUploadService: ContainerUploadService, transfer: Transfer, imsBackendMock: ImsBackendMock) => {

--- a/src/providers/container-upload-service.spec.ts
+++ b/src/providers/container-upload-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { FileUploadOptions, Transfer } from '@ionic-native/transfer';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
 import { TransferMock } from '../mocks/providers/transfer-mock';
@@ -8,7 +8,7 @@ import { ContainerUploadService } from './container-upload-service';
 
 describe('Provider: ContainerUploadService', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [
@@ -18,7 +18,7 @@ describe('Provider: ContainerUploadService', () => {
       ],
       imports: []
     });
-  }));
+  });
 
   it('Should post to a container', inject([ContainerUploadService, Transfer, ImsBackendMock], (containerUploadService: ContainerUploadService, transfer: Transfer, imsBackendMock: ImsBackendMock) => {
     const image = new Image('a.jpg', '/dev/0');

--- a/src/providers/drag-event-counter-service.spec.ts
+++ b/src/providers/drag-event-counter-service.spec.ts
@@ -11,7 +11,7 @@ describe('Service: DragEventCounter', () => {
         DragEventCounterService
       ],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('first event should be true if inc is called once', inject([DragEventCounterService], (dragEventCounterService: DragEventCounterService) => {

--- a/src/providers/drag-event-counter-service.spec.ts
+++ b/src/providers/drag-event-counter-service.spec.ts
@@ -1,10 +1,10 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { DragEventInvalidStateError } from './../models/errors/drag-event-invalid-state-error';
 import { DragEventCounterService } from './drag-event-counter-service';
 
 describe('Service: DragEventCounter', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [
@@ -12,7 +12,7 @@ describe('Service: DragEventCounter', () => {
       ],
       imports: []
     });
-  }));
+  });
 
   it('first event should be true if inc is called once', inject([DragEventCounterService], (dragEventCounterService: DragEventCounterService) => {
     dragEventCounterService.inc('a1');

--- a/src/providers/drag-event-service.spec.ts
+++ b/src/providers/drag-event-service.spec.ts
@@ -1,12 +1,12 @@
 import { Renderer2 } from '@angular/core';
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { DragEventMock } from './../mocks/drag-event-mock';
 import { DragEventCounterService } from './drag-event-counter-service';
 import { DragEventService } from './drag-event-service';
 
 describe('Provider: DragEventService', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [
@@ -14,7 +14,7 @@ describe('Provider: DragEventService', () => {
       ],
       imports: []
     });
-  }));
+  });
 
   it('should prevent standard action for dragstart', inject([DragEventService], (service: DragEventService) => {
     const event = new DragEventMock('dragstart');

--- a/src/providers/drag-event-service.spec.ts
+++ b/src/providers/drag-event-service.spec.ts
@@ -13,7 +13,7 @@ describe('Provider: DragEventService', () => {
         Renderer2, DragEventService, DragEventCounterService
       ],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('should prevent standard action for dragstart', inject([DragEventService], (service: DragEventService) => {

--- a/src/providers/entries-service.spec.ts
+++ b/src/providers/entries-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
 import { EntriesService } from './entries-service';
@@ -8,7 +8,7 @@ import { TokenService } from './token-service';
 
 describe('Provider: EntriesService', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [
@@ -27,7 +27,7 @@ describe('Provider: EntriesService', () => {
       ],
       imports: [HttpModule]
     });
-  }));
+  });
 
   it('Gets parent image entries', inject([EntriesService, ImsBackendMock], (entriesService: EntriesService, mockImsBackend: ImsBackendMock) => {
     entriesService.getParentImageEntries(mockImsBackend.credential, mockImsBackend.filterId, mockImsBackend.query).subscribe(

--- a/src/providers/entries-service.spec.ts
+++ b/src/providers/entries-service.spec.ts
@@ -26,7 +26,7 @@ describe('Provider: EntriesService', () => {
         }
       ],
       imports: [HttpModule]
-    }).compileComponents();
+    });
   }));
 
   it('Gets parent image entries', inject([EntriesService, ImsBackendMock], (entriesService: EntriesService, mockImsBackend: ImsBackendMock) => {

--- a/src/providers/ims-error-handler.spec.ts
+++ b/src/providers/ims-error-handler.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { AlertController, IonicErrorHandler } from 'ionic-angular';
 import { AlertMock } from './../mocks/mocks';
 import { ImsError } from './../models/errors/ims-error';
@@ -7,16 +7,14 @@ import { ImsErrorHandler } from './ims-error-handler';
 
 describe('IMS Error Handler: Error Handler', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
       providers: [ImsErrorHandler, AlertService, IonicErrorHandler,
         { provide: AlertController, useClass: AlertMock }],
       imports: []
     });
-  }));
+  });
 
   it('should handle a imsError and show alert with displayed message', inject([ImsErrorHandler, AlertService], (imsErrorHandler: ImsErrorHandler, alertService: AlertService) => {
     const imsError = new ImsError('Ims Error Text', 'Error Object');

--- a/src/providers/ims-error-handler.spec.ts
+++ b/src/providers/ims-error-handler.spec.ts
@@ -15,7 +15,7 @@ describe('IMS Error Handler: Error Handler', () => {
       providers: [ImsErrorHandler, AlertService, IonicErrorHandler,
         { provide: AlertController, useClass: AlertMock }],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('should handle a imsError and show alert with displayed message', inject([ImsErrorHandler, AlertService], (imsErrorHandler: ImsErrorHandler, alertService: AlertService) => {

--- a/src/providers/ims-service.spec.ts
+++ b/src/providers/ims-service.spec.ts
@@ -23,7 +23,7 @@ describe('Provider: ImsService', () => {
         }
       ],
       imports: [HttpModule]
-    }).compileComponents();
+    });
   }));
 
   it('Ims Version', inject([ImsService, ImsBackendMock], (imsService: ImsService, imsBackendMock: ImsBackendMock) => {

--- a/src/providers/ims-service.spec.ts
+++ b/src/providers/ims-service.spec.ts
@@ -1,16 +1,13 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
 import { ImsService } from './ims-service';
 
 describe('Provider: ImsService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
-
       providers: [
         ImsService,
         ImsBackendMock,
@@ -24,7 +21,7 @@ describe('Provider: ImsService', () => {
       ],
       imports: [HttpModule]
     });
-  }));
+  });
 
   it('Ims Version', inject([ImsService, ImsBackendMock], (imsService: ImsService, imsBackendMock: ImsBackendMock) => {
     imsService.getInfo(imsBackendMock.credential).subscribe(

--- a/src/providers/loading-service.spec.ts
+++ b/src/providers/loading-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { LoadingController } from 'ionic-angular';
 import 'rxjs/add/observable/concat';
 import 'rxjs/add/observable/of';
@@ -8,15 +8,13 @@ import { LoadingService } from './loading-service';
 
 describe('Provider: LoadingService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
       providers: [LoadingService, { provide: LoadingController, useClass: LoadingMock }],
       imports: []
     });
-  }));
+  });
 
   it('Success function called in execute wiht loading', inject([LoadingService, LoadingController], (loadingService: LoadingService, loadingController: LoadingController) => {
     let toCheck = '';

--- a/src/providers/loading-service.spec.ts
+++ b/src/providers/loading-service.spec.ts
@@ -15,7 +15,7 @@ describe('Provider: LoadingService', () => {
       declarations: [],
       providers: [LoadingService, { provide: LoadingController, useClass: LoadingMock }],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('Success function called in execute wiht loading', inject([LoadingService, LoadingController], (loadingService: LoadingService, loadingController: LoadingController) => {

--- a/src/providers/model-service.spec.ts
+++ b/src/providers/model-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
 import { ImsService } from './ims-service';
@@ -6,12 +6,9 @@ import { ModelService } from './model-service';
 
 describe('Provider: ModelService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
-
       providers: [
         ModelService,
         ImsService,
@@ -26,7 +23,7 @@ describe('Provider: ModelService', () => {
       ],
       imports: [HttpModule]
     });
-  }));
+  });
 
   it('Should get image table metadata fields', inject([ModelService, ImsBackendMock], (modelService: ModelService, imsBackendMock: ImsBackendMock) => {
     modelService.getMetadataFieldsOfImageTable(imsBackendMock.credential, imsBackendMock.modelArchiveName).subscribe(

--- a/src/providers/model-service.spec.ts
+++ b/src/providers/model-service.spec.ts
@@ -25,7 +25,7 @@ describe('Provider: ModelService', () => {
         }
       ],
       imports: [HttpModule]
-    }).compileComponents();
+    });
   }));
 
   it('Should get image table metadata fields', inject([ModelService, ImsBackendMock], (modelService: ModelService, imsBackendMock: ImsBackendMock) => {

--- a/src/providers/query-builder-service.spec.ts
+++ b/src/providers/query-builder-service.spec.ts
@@ -10,7 +10,7 @@ describe('Provider: QueryBuilderService', () => {
       declarations: [],
       providers: [QueryBuilderService],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('Create a query string from 1 query fragment', inject([QueryBuilderService], (queryBuilderService: QueryBuilderService) => {

--- a/src/providers/query-builder-service.spec.ts
+++ b/src/providers/query-builder-service.spec.ts
@@ -1,17 +1,16 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { QueryFragment } from './../models/query-fragment';
 import { QueryBuilderService } from './query-builder-service';
 
 describe('Provider: QueryBuilderService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [QueryBuilderService],
       imports: []
     });
-  }));
+  });
 
   it('Create a query string from 1 query fragment', inject([QueryBuilderService], (queryBuilderService: QueryBuilderService) => {
     const queryFragment1 = new QueryFragment('key', 'value');

--- a/src/providers/setting-service.spec.ts
+++ b/src/providers/setting-service.spec.ts
@@ -13,7 +13,7 @@ describe('Provider: SettingService', () => {
       declarations: [],
       providers: [SettingService, { provide: Storage, useClass: StorageMock }],
       imports: []
-    }).compileComponents();
+    });
   }));
 
   it('Should initialize with default values', inject([SettingService], (settingService: SettingService) => {

--- a/src/providers/setting-service.spec.ts
+++ b/src/providers/setting-service.spec.ts
@@ -6,15 +6,13 @@ import { SettingService } from './setting-service';
 
 describe('Provider: SettingService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
       providers: [SettingService, { provide: Storage, useClass: StorageMock }],
       imports: []
     });
-  }));
+  });
 
   it('Should initialize with default values', inject([SettingService], (settingService: SettingService) => {
     settingService.isShowRestUrlField().subscribe(isShowRestUrlField => expect(isShowRestUrlField).toBe(settingService.isShowRestUrlFieldDefault));

--- a/src/providers/token-service.spec.ts
+++ b/src/providers/token-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
 import { Token } from '../models/token';
@@ -7,12 +7,9 @@ import { TokenService } from './token-service';
 
 describe('Provider: TokenService', () => {
 
-  beforeEach(async(() => {
-
+  beforeEach(() => {
     TestBed.configureTestingModule({
-
       declarations: [],
-
       providers: [
         TokenService,
         ImsService,
@@ -27,7 +24,7 @@ describe('Provider: TokenService', () => {
       ],
       imports: [HttpModule]
     });
-  }));
+  });
 
   it('Should get Token Location for Segment Name', inject([TokenService, ImsBackendMock], (tokenService: TokenService, imsBackendMock: ImsBackendMock) => {
     tokenService.getTokenForSegment(imsBackendMock.credential).subscribe(

--- a/src/providers/token-service.spec.ts
+++ b/src/providers/token-service.spec.ts
@@ -26,7 +26,7 @@ describe('Provider: TokenService', () => {
         }
       ],
       imports: [HttpModule]
-    }).compileComponents();
+    });
   }));
 
   it('Should get Token Location for Segment Name', inject([TokenService, ImsBackendMock], (tokenService: TokenService, imsBackendMock: ImsBackendMock) => {

--- a/src/providers/upload-service.spec.ts
+++ b/src/providers/upload-service.spec.ts
@@ -31,7 +31,7 @@ describe('Provider: UploadService', () => {
         }
       ],
       imports: [HttpModule]
-    }).compileComponents();
+    });
   }));
 
   it('Should create a container location', inject([UploadService, ImsBackendMock], (uploadService: UploadService, imsBackendMock: ImsBackendMock) => {

--- a/src/providers/upload-service.spec.ts
+++ b/src/providers/upload-service.spec.ts
@@ -1,4 +1,4 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, HttpModule } from '@angular/http';
 import { Transfer } from '@ionic-native/transfer';
 import { ImsBackendMock } from '../mocks/ims-backend-mock';
@@ -12,7 +12,7 @@ import { UploadService } from './upload-service';
 
 describe('Provider: UploadService', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
       providers: [
@@ -32,7 +32,7 @@ describe('Provider: UploadService', () => {
       ],
       imports: [HttpModule]
     });
-  }));
+  });
 
   it('Should create a container location', inject([UploadService, ImsBackendMock], (uploadService: UploadService, imsBackendMock: ImsBackendMock) => {
     uploadService.createContainerLocation(imsBackendMock.credential, imsBackendMock.filterId, imsBackendMock.token).subscribe(


### PR DESCRIPTION
As stated in the Angular docs, WebPack developers need not call compileComponents because it inlines templates and css as part of the automated build process that precedes running the test.
https://angular.io/guide/testing#compilecomponents

Using async inside the beforeEach seems to be necessary as a workaround for a jasmine issue with browser disconnects in Travis and Windows, see https://github.com/jasmine/jasmine/issues/1327.
For cleaner code this removes the asyncs and pins jasmine to 2.5.2 in package.json.