### PR TITLE
fix(app): add a reason for camera and photo library access on ios

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -87,7 +87,10 @@
   <plugin name="cordova-plugin-statusbar" spec="2.2.1"/>
   <plugin name="cordova-plugin-device" spec="1.1.4"/>
   <plugin name="cordova-plugin-splashscreen" spec="~4.0.1"/>
-  <plugin name="cordova-plugin-camera" spec="~2.4.0"/>
+  <plugin name="cordova-plugin-camera" spec="~2.4.0">
+    <variable name="CAMERA_USAGE_DESCRIPTION" value="Arkivar brauch Zugriff auf deine Kamera." />
+    <variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="Arkivar braucht Zugriff auf deine Fotos." />
+  </plugin>
   <plugin name="cordova-plugin-file-transfer" spec="~1.6.2"/>
   <plugin name="cordova-plugin-file" spec="~4.3.2"/>
   <icon src="resources/android/icon/drawable-xhdpi-icon.png"/>

--- a/config.xml
+++ b/config.xml
@@ -88,7 +88,7 @@
   <plugin name="cordova-plugin-device" spec="1.1.4"/>
   <plugin name="cordova-plugin-splashscreen" spec="~4.0.1"/>
   <plugin name="cordova-plugin-camera" spec="~2.4.0">
-    <variable name="CAMERA_USAGE_DESCRIPTION" value="Arkivar brauch Zugriff auf deine Kamera."/>
+    <variable name="CAMERA_USAGE_DESCRIPTION" value="Arkivar braucht Zugriff auf deine Kamera."/>
     <variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="Arkivar braucht Zugriff auf deine Fotos."/>
   </plugin>
   <plugin name="cordova-plugin-file-transfer" spec="~1.6.2"/>

--- a/config.xml
+++ b/config.xml
@@ -88,8 +88,8 @@
   <plugin name="cordova-plugin-device" spec="1.1.4"/>
   <plugin name="cordova-plugin-splashscreen" spec="~4.0.1"/>
   <plugin name="cordova-plugin-camera" spec="~2.4.0">
-    <variable name="CAMERA_USAGE_DESCRIPTION" value="Arkivar brauch Zugriff auf deine Kamera." />
-    <variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="Arkivar braucht Zugriff auf deine Fotos." />
+    <variable name="CAMERA_USAGE_DESCRIPTION" value="Arkivar brauch Zugriff auf deine Kamera."/>
+    <variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="Arkivar braucht Zugriff auf deine Fotos."/>
   </plugin>
   <plugin name="cordova-plugin-file-transfer" spec="~1.6.2"/>
   <plugin name="cordova-plugin-file" spec="~4.3.2"/>

--- a/package.json
+++ b/package.json
@@ -100,7 +100,10 @@
   },
   "cordova": {
     "plugins": {
-      "cordova-plugin-camera": {},
+      "cordova-plugin-camera": {
+        "CAMERA_USAGE_DESCRIPTION": "Arkivar brauch Zugriff auf deine Kamera.",
+        "PHOTOLIBRARY_USAGE_DESCRIPTION": "Arkivar braucht Zugriff auf deine Fotos."
+      },
       "cordova-plugin-console": {},
       "cordova-plugin-device": {},
       "cordova-plugin-file": {},

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "cordova": {
     "plugins": {
       "cordova-plugin-camera": {
-        "CAMERA_USAGE_DESCRIPTION": "Arkivar brauch Zugriff auf deine Kamera.",
+        "CAMERA_USAGE_DESCRIPTION": "Arkivar braucht Zugriff auf deine Kamera.",
         "PHOTOLIBRARY_USAGE_DESCRIPTION": "Arkivar braucht Zugriff auf deine Fotos."
       },
       "cordova-plugin-console": {},


### PR DESCRIPTION
App store validation requires that these strings are not empty.