### PR TITLE
feat(entries): display only field content in entries list

### DIFF
--- a/e2e/entries.e2e-spec.ts
+++ b/e2e/entries.e2e-spec.ts
@@ -47,7 +47,7 @@ describe('Entries E2E Test', () => {
     settingEntriesFieldsPage.loadPage();
     Helpers.toggleFieldSettings(settingEntriesFieldsPage.settingsEntriesFieldMEMOFELDToggle);
     entriesPage.reloadPage();
-    entriesPage.verifyFirstFieldStartsWith('MEMOFELD');
+    entriesPage.verifyFirstFieldName('MEMOFELD');
     entriesPage.verifyOnlyFirstFieldVisible();
   });
 
@@ -56,8 +56,8 @@ describe('Entries E2E Test', () => {
     Helpers.toggleFieldSettings(settingEntriesFieldsPage.settingsEntriesFieldMEMOFELDToggle);
     Helpers.toggleFieldSettings(settingEntriesFieldsPage.settingsEntriesFieldTEXTFELDToggle);
     entriesPage.reloadPage();
-    entriesPage.verifyFirstFieldStartsWith('MEMOFELD');
-    entriesPage.verifySecondFieldStartsWith('TEXTFELD');
+    entriesPage.verifyFirstFieldName('MEMOFELD');
+    entriesPage.verifySecondFieldName('TEXTFELD');
     entriesPage.verifyOnlyFirstTwoFieldsVisible();
   });
 

--- a/e2e/page-objects/entries-page-object.ts
+++ b/e2e/page-objects/entries-page-object.ts
@@ -64,12 +64,12 @@ export class EntriesPageObject {
     browser.wait(ExpectedConditions.invisibilityOf(this.entriesThirdMetaDataField), Helpers.DEFAULT_WAIT_TIMEOUT);
   }
 
-  public verifyFirstFieldStartsWith(text: string): void {
-    this.verifyFieldStartsWith(text, this.entriesFirstMetaDataField);
+  public verifyFirstFieldName(text: string): void {
+    this.verifyFieldName(text, this.entriesFirstMetaDataField);
   }
 
-  public verifySecondFieldStartsWith(text: string): void {
-    this.verifyFieldStartsWith(text, this.entriesSecondMetaDataField);
+  public verifySecondFieldName(text: string): void {
+    this.verifyFieldName(text, this.entriesSecondMetaDataField);
   }
 
   public verifyDragoverlayVisible(): void {
@@ -94,9 +94,9 @@ export class EntriesPageObject {
     this.entriesItem.getAttribute('id').then(entriesItemId => Helpers.sendDragLeaveEventToElement(entriesItemId));
   }
 
-  private verifyFieldStartsWith(text: string, field: ElementFinder): void {
+  private verifyFieldName(expectedFieldname: string, field: ElementFinder): void {
     browser.wait(ExpectedConditions.visibilityOf(field), Helpers.DEFAULT_WAIT_TIMEOUT);
-    expect(field.getText()).toMatch(new RegExp('^' + text));
+    field.getAttribute('fieldname').then(actualFieldname => expect(actualFieldname).toEqual(expectedFieldname));
   }
 
   private removeEventlistenerFromFilePicker(): void {

--- a/src/pages/entries/entries.html
+++ b/src/pages/entries/entries.html
@@ -15,7 +15,7 @@
       <ion-item *ngFor="let entry of entries" id="entriesItem{{entry.fields[parentImageReferenceField]}}" (dragleave)="handleDragEvent($event)" (dragenter)="handleDragEvent($event)" (dragstart)="handleDragEvent($event)" (dragover)="handleDragEvent($event)" (drop)="handleDragEvent($event, entry.fields[parentImageReferenceField], entry.fields[titleField])">
         <div class="entryContent">
           <h1 ion-text color="primary">{{entry.fields[titleField]}}</h1>
-          <div *ngFor="let field of fields" class="entries-fields">{{entry.fields[field.name]}}</div>
+          <div *ngFor="let field of fields" attr.fieldname="{{field.name}}" class="entries-fields">{{entry.fields[field.name]}}</div>
         </div>
         <button *ngIf="pictureFromCameraEnabled" ion-button (click)="takePictureForEntry(entry.fields[parentImageReferenceField], entry.fields[titleField])" class="cameraButton" item-right>
           <ion-icon name="camera"></ion-icon>

--- a/src/pages/entries/entries.html
+++ b/src/pages/entries/entries.html
@@ -15,7 +15,7 @@
       <ion-item *ngFor="let entry of entries" id="entriesItem{{entry.fields[parentImageReferenceField]}}" (dragleave)="handleDragEvent($event)" (dragenter)="handleDragEvent($event)" (dragstart)="handleDragEvent($event)" (dragover)="handleDragEvent($event)" (drop)="handleDragEvent($event, entry.fields[parentImageReferenceField], entry.fields[titleField])">
         <div class="entryContent">
           <h1 ion-text color="primary">{{entry.fields[titleField]}}</h1>
-          <div *ngFor="let field of fields" class="entries-fields">{{field.name}} : {{entry.fields[field.name]}}</div>
+          <div *ngFor="let field of fields" class="entries-fields">{{entry.fields[field.name]}}</div>
         </div>
         <button *ngIf="pictureFromCameraEnabled" ion-button (click)="takePictureForEntry(entry.fields[parentImageReferenceField], entry.fields[titleField])" class="cameraButton" item-right>
           <ion-icon name="camera"></ion-icon>


### PR DESCRIPTION
The field name in the entries list needs a lot of space. This leads to a hiding of content in the entries page.
This feature removes the display of the field name and shows the field content only. 

Closes #519 