### PR TITLE
fix(upload): selection not working immediately after adding keyword field

### DIFF
--- a/src/pages/upload/upload.spec.ts
+++ b/src/pages/upload/upload.spec.ts
@@ -354,6 +354,19 @@ describe('Page: Upload', () => {
     page.showSuggestionIfAvailable(page.fields[0]);
     expect(keywordService.getKeywordCatalog).toHaveBeenCalledTimes(1);
     expect(navCtrl.push).toHaveBeenCalledWith(KeywordsPage, { field: imsBackendMock.modelFieldOptionalString, keywords: imsBackendMock.keywordCatalog.keywords, uploadrootpage: page.navCtrl.getActive()});
-
   }));
+
+  it('Subscribes to keywordSelection event on page load', inject([AuthService, ImsBackendMock, Events], (authService: AuthService, imsBackendMock: ImsBackendMock, events: Events) => {
+    spyOn(events, 'subscribe').and.callThrough();
+    authService.setArchive(imsBackendMock.policeFilter);
+    page.ionViewDidLoad();
+    expect(events.subscribe).toHaveBeenCalledWith(page.keywordSelectionTopic, jasmine.any(Function));
+  }));
+
+  it('Unsubscribes from keywordSelection event on page unload', inject([Events], (events: Events) => {
+    spyOn(events, 'unsubscribe').and.callThrough();
+    page.ionViewWillUnload();
+    expect(events.unsubscribe).toHaveBeenCalledWith(page.keywordSelectionTopic);
+  }));
+
 });

--- a/src/pages/upload/upload.ts
+++ b/src/pages/upload/upload.ts
@@ -37,6 +37,7 @@ export class UploadPage {
   public parentImageReferenceField: string;
   public pictureFromCameraEnabled: boolean;
   public showDragOverlay: boolean = false;
+  public readonly keywordSelectionTopic: string = 'keyword: selected';
 
   constructor(public navCtrl: NavController, public navParams: NavParams, public cameraService: CameraService, public uploadService: UploadService, public authService: AuthService, public loadingService: LoadingService, public toastCtrl: ToastController, public modelService: ModelService, public formBuilder: FormBuilder, public settingService: SettingService, public fieldValidatorService: FieldValidatorService, public domSanitizer: DomSanitizer, public platform: Platform, public browserFileuploadSelectorService: BrowserFileuploadSelectorService, public renderer: Renderer2, public dragEventService: DragEventService, public events: Events, public keywordService: KeywordService) {
     this.images = navParams.get('images');
@@ -44,12 +45,16 @@ export class UploadPage {
     this.entryTitle = navParams.get('entryTitle');
     this.pictureFromCameraEnabled = settingService.isPictureFromCameraEnabled();
     this.dragEventService.preventEventsOnBody(renderer);
-    this.events.subscribe('keyword: selected', (field, keyword) => { this.fillFormWithKeyword(field, keyword); });
   }
 
   public ionViewDidLoad(): void {
     this.loadParentImageReferenceField();
     this.loadUploadFields();
+    this.events.subscribe(this.keywordSelectionTopic, (field, keyword) => { this.fillFormWithKeyword(field, keyword); });
+  }
+
+  public ionViewWillUnload(): void {
+    this.events.unsubscribe(this.keywordSelectionTopic);
   }
 
   public loadParentImageReferenceField(): void {


### PR DESCRIPTION
When a keyword field was added to the list of upload fields the selection of a keyword only started worked after reloading the whole app.

Re-subscribe to keyword selection events on each visit of the upload page to ensure the event callback is aware of changes in the form fields.

Closes #570 