### PR TITLE
docs: use Ionic instead of Ionic 2 as framework name

### DIFF
--- a/docs/Frameworkentscheid.md
+++ b/docs/Frameworkentscheid.md
@@ -25,7 +25,7 @@ Nur eine Auswahl der wichtigsten Framworkanforderungen konnte im im Prototyp imp
 | 17 | Authentifizierung | Ja | Ja | Ja |
 | 21 | Dynamische Felder | Ja, jedoch nicht optimal | Ja | Ja |			
 
-## Ionic 2
+## Ionic
 ### Vorteile
 - Gute und komplette Bibliotheksfunktionen für HW-Ansteuerung
 - Layout kann in HTML beschrieben werden
@@ -61,4 +61,4 @@ Nur eine Auswahl der wichtigsten Framworkanforderungen konnte im im Prototyp imp
 - Wird im Webbrowser nicht unterstützt
 
 ## Entscheid
-Alle Frameworks liefern eine gute Ausgangslage für die Entwicklung des mobilen Clients. Wir haben uns für Ionic 2 entschieden, da uns die integrierten Bibliotheksfunktionen und die eine einfache Layouterstellung überzeugt haben. Ausserdem ist es lauffähig im Webbrowser. Ionic 2 baut auf dem Angular Framework auf. Dies hilft bei der Strukturierung des Quellcodes. Auch wenn wir noch Vorbehalte gegenüber der fehlenden (Global Player) Unterstützung haben, denken wir, dass die Vorteile überwiegen.
+Alle Frameworks liefern eine gute Ausgangslage für die Entwicklung des mobilen Clients. Wir haben uns für Ionic entschieden, da uns die integrierten Bibliotheksfunktionen und die eine einfache Layouterstellung überzeugt haben. Ausserdem ist es lauffähig im Webbrowser. Ionic baut auf dem Angular Framework auf. Dies hilft bei der Strukturierung des Quellcodes. Auch wenn wir noch Vorbehalte gegenüber der fehlenden (Global Player) Unterstützung haben, denken wir, dass die Vorteile überwiegen.

--- a/docs/Frameworkentscheid.md
+++ b/docs/Frameworkentscheid.md
@@ -3,7 +3,7 @@
 
 Für die Framework Entscheidung wurde pro Framework ein Prototyp erstellt. Mithilfe dieser Prototypen sollte abgeklärt werden, ob das Framework unseren Anforderungen entspricht. Die Anforderungen an den Prototyp wurden im Dokument [Frameworkanforderungen](frameworkanforderungen.md) zusammengefasst. Die Prototypen und Frameworkbeschreibungen sind auf den GitHub-Seiten einsehbar:
 
-- [Ionic 2](https://github.com/IMSmobile/ionic2-prototype)
+- [Ionic](https://github.com/IMSmobile/ionic2-prototype)
 - [React Native](https://github.com/IMSmobile/rn-prototype)
 - [Xamarin](https://github.com/IMSmobile/XamarinPrototype)
 
@@ -11,7 +11,7 @@ Für die Framework Entscheidung wurde pro Framework ein Prototyp erstellt. Mithi
 
 Nur eine Auswahl der wichtigsten Framworkanforderungen konnte im im Prototyp implementiert und bewertet werden.
 
-| ID | Anforderung | Ionic 2 | React Native | Xamarin |
+| ID | Anforderung | Ionic | React Native | Xamarin |
 | -- | ----------- | ------- | ------------ | ------- |
 |  1 | Android Support | Ja | Ja | Ja |
 |  2 | iOS-Support |	Ja |	Ja | Ja |

--- a/docs/decisionlog.md
+++ b/docs/decisionlog.md
@@ -47,7 +47,7 @@ Unsere Entscheidungen werden hier protokolliert.
 - Beim HSR Review übernimmt Michael die Rolle des _Lead Autors_ und Niklaus die Rolle des _Lead Prüfers_.
 
 ## 24. März 2017
-- Wir entwickeln mit dem Framework Ionic2.
+- Wir entwickeln mit dem Framework Ionic.
 - Pro Sprint ist eine Person im Team verantwortlich für die Kommunikation mit Stakeholdern und Betreuer.
 - Sprint Backlog und Backlog müssen immer priorisiert sein.
 

--- a/docs/projektplan.md
+++ b/docs/projektplan.md
@@ -286,7 +286,7 @@ Um besser mit Ionic arbeiten zu können, müssen folgende Plugins der Entwicklun
 
 | Plugin      | Befehl | Beschreibung |
 |---------|-------------|--------|
-|[Ionic 2 Commands with Snippets](https://marketplace.visualstudio.com/items?itemName=Thavarajan.ionic2) | `ext install ionic2` | Ionic 2 Code Completion       |
+|[Ionic 2 Commands with Snippets](https://marketplace.visualstudio.com/items?itemName=Thavarajan.ionic2) | `ext install ionic2` | Ionic Code Completion       |
 | [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) | `ext install debugger-for-chrome` | Javascript und Typescript Debugging via Google Chrome |
 |[TSLint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) | `ext install tslint` | Integration des [tslint Linters](#code-guideline) für TypeScript |
 |[Markdown TOC](https://marketplace.visualstudio.com/items?itemName=AlanWalk.markdown-toc) | `ext install markdown-toc` | Automatisiertes generieren des Inhaltsverzeichnis (Table of Content) für Markdown Dateien. |

--- a/docs/projektplan.md
+++ b/docs/projektplan.md
@@ -241,12 +241,12 @@ Unsere Qualitätsmassnahmen umfassen folgende Punkte:
 | Story Map                                                 | Gesamte Projektdauer (ausser bei Prototyp) | organisatorisch | Übersicht behalten
 
 ### Framework
-Für die Entwicklung der Software benutzen wir das Framework [Ionic 2](http://ionicframework.com/).
+Für die Entwicklung der Software benutzen wir das Framework [Ionic](http://ionicframework.com/).
 Die Anforderungen an das Framework wurden in einem speziell dafür geschaffenen [Anforderungskatalog](frameworkanforderungen.md) festgehalten. Drei Prototypen wurden erstellt und gegen die Anforderungen geprüft. Die Auswahl des Frameworks kann im Dokument [Framework Entscheid](Frameworkentscheid.md) nachgelesen werden.  
 
 | Framework   | Prototype   |
 |---|---|
-| Ionic 2  | https://github.com/IMSmobile/ionic2-prototype   |
+| Ionic | https://github.com/IMSmobile/ionic2-prototype   |
 | Xamarin  | https://github.com/IMSmobile/XamarinPrototype  |
 | React Native | https://github.com/IMSmobile/rn-prototype   |
 

--- a/docs/sad.md
+++ b/docs/sad.md
@@ -67,7 +67,7 @@ Die Design Prinzipien beschreiben die wichtigsten architektischen Richtlinien un
 
 ### Ordnerstruktur Konventionen
 
-Damit das Projekt sauber strukturiert ist und sich neue Entwickler rasch zurechtfinden, verwenden wir eine Ordnerstruktur Konvention. Diese entsprechen im Grundsatz den Konventionen eines Ionic 2 Projekts.  
+Damit das Projekt sauber strukturiert ist und sich neue Entwickler rasch zurechtfinden, verwenden wir eine Ordnerstruktur Konvention. Diese entsprechen im Grundsatz den Konventionen eines Ionic Projekts.  
 
     .
     ├── e2e                          # Automatisierte End to End Tests


### PR DESCRIPTION
Closes #561 