### PR TITLE
docs: quote agile manifesto and assembly flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 
 ## Quellen
 - Agiles Manifest: http://agilemanifesto.org/iso/de/manifesto.html
+- Assembly Flow: https://forum.ionicframework.com/t/is-there-a-graphic-diagram-available-that-shows-how-ionic-2-and-all-related-technologies-connect/88375/19
 - Icons: https://icons8.com/
 - Wiegers Priorisierungsmatrix: http://www.orgismus.de/methoden/priorisieren-aber-richtig/
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 | [Testprotokoll](docs/testsession/sessionreport.md) | Resultat der explorativen Testsession                                |
 
 ## Quellen
+- Agiles Manifest: http://agilemanifesto.org/iso/de/manifesto.html
 - Icons: https://icons8.com/
 - Wiegers Priorisierungsmatrix: http://www.orgismus.de/methoden/priorisieren-aber-richtig/
 

--- a/docs/projektplan.md
+++ b/docs/projektplan.md
@@ -304,7 +304,7 @@ Alle Entwickler der Applikation stehen hinter dem [Agilen Manifest](http://agile
 > 
 > Das heisst, obwohl wir die Werte auf der rechten Seite wichtig finden, schätzen wir die Werte auf der linken Seite höher ein.
 
-Das Prozessvorgehen orientiert sich stark an Scrum. Die meisten Events und Artefakte wurden direkt vom [Scrum Guide](http://www.scrumguides.org/scrum-guide.html) übernommen. Es gibt jedoch Abweichungen bezüglich dem Scrum Team.
+Das Prozessvorgehen orientiert sich stark an Scrum. Die meisten Events und Artefakte wurden direkt vom [Scrum Guide](http://www.scrumguides.org/scrum-guide.html) übernommen.
 
 #### Events
 

--- a/docs/projektplan.md
+++ b/docs/projektplan.md
@@ -295,14 +295,14 @@ Um eine Ionic App zu debuggen:
 #### Vorgehen
 Um ein rasches Kundenfeedback zu erhalten und damit wir abschlussorientiert arbeiten können, wird das Projekt mit agilen Methoden entwickelt.
 
-Alle Entwickler der Applikation stehen hinter dem [Agilen Manifest](http://agilemanifesto.org/iso/de/manifesto.html).
+Alle Entwickler der Applikation stehen hinter dem [Agilen Manifest](http://agilemanifesto.org/iso/de/manifesto.html):
 
-**Individuen und Interaktionen** mehr als Prozesse und Werkzeuge  
-**Funktionierende Software** mehr als umfassende Dokumentation  
-**Zusammenarbeit mit dem Kunden** mehr als Vertragsverhandlung  
-**Reagieren auf Veränderung** mehr als das Befolgen eines Plans  
-
-Das heisst, obwohl wir die Werte auf der rechten Seite wichtig finden, schätzen wir die Werte auf der linken Seite höher ein.
+> **Individuen und Interaktionen** mehr als Prozesse und Werkzeuge  
+> **Funktionierende Software** mehr als umfassende Dokumentation  
+> **Zusammenarbeit mit dem Kunden** mehr als Vertragsverhandlung  
+> **Reagieren auf Veränderung** mehr als das Befolgen eines Plans  
+> 
+> Das heisst, obwohl wir die Werte auf der rechten Seite wichtig finden, schätzen wir die Werte auf der linken Seite höher ein.
 
 Das Prozessvorgehen orientiert sich stark an Scrum. Die meisten Events und Artefakte wurden direkt vom [Scrum Guide](http://www.scrumguides.org/scrum-guide.html) übernommen. Es gibt jedoch Abweichungen bezüglich dem Scrum Team.
 


### PR DESCRIPTION
Add links to the source of the agile manifesto and the original author of the assemby flow.
Also remove a rather meaningless sentence concerning the scrum team.

Part of #532 