### PR TITLE
test: disable e2e execution due to missing ims rest server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_script:
 script: 
   - npm run lint
   - npm run test-coverage
-  - npm run e2e
   - chmod ugo+x scripts/version-consistency.sh
   - ./scripts/version-consistency.sh
   - chmod ugo+x scripts/run-ionic-cloud-builds-on-pr-or-master.sh

--- a/docs/projektplan.md
+++ b/docs/projektplan.md
@@ -408,6 +408,9 @@ describe("A module ", function() {
 ```
 
 #### End to End Testing
+
+:warning: Nach Fertigstellung der Masterarbeit wurde der von der HSR zur Verfügung gestellte IMS Service ausgeschalten. Deshalb wurde die Ausführung der E2E Tests im Travis deaktiviert. 
+
 Bei End to End Testing werden Anforderungen automatisiert getestet. Es wird sichergestellt, dass die Integration und Zusammenarbeit der verschiedenen Komponenten funktioniert. Diese Tests dauern in der Regel länger und sollen von einem Continuous Integration Server automatisiert ausgeführt werden.
 
 Mit folgendem Befehl können alle End to End Tests ausgeführt werden.


### PR DESCRIPTION
After the termination of the master thesis the IMS Rest Server has been shut down. To ensure the open source project can still be build the e2e execution on travis has been disabled.